### PR TITLE
[#7] Add ability to print time and thread id

### DIFF
--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -34,8 +34,9 @@ library
                      , co-log-core
                      , contravariant ^>= 1.5
                      , mtl
-                     , relude
+                     , relude ^>= 0.3.0
                      , text
+                     , time
                      , transformers >= 0.5
 
   ghc-options:         -Wall
@@ -52,6 +53,8 @@ library
                       GeneralizedNewtypeDeriving
                       InstanceSigs
                       OverloadedStrings
+                      RecordWildCards
+                      TypeApplications
 
 executable play-colog
   hs-source-dirs:      example
@@ -59,7 +62,7 @@ executable play-colog
 
   build-depends:       base-noprelude
                      , co-log
-                     , relude ^>= 0.1.1
+                     , relude
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/co-log/src/Colog/Actions.hs
+++ b/co-log/src/Colog/Actions.hs
@@ -57,7 +57,7 @@ withLogStringFile path action = withFile path AppendMode $ action . logStringHan
 
 {- | Action that prints 'ByteString' to stdout. -}
 logByteStringStdout :: MonadIO m => LogAction m ByteString
-logByteStringStdout = LogAction putStrLn
+logByteStringStdout = LogAction putBSLn
 
 {- | Action that prints 'ByteString' to stderr. -}
 logByteStringStderr :: MonadIO m => LogAction m ByteString

--- a/co-log/src/Colog/Monad.hs
+++ b/co-log/src/Colog/Monad.hs
@@ -16,11 +16,11 @@ import Control.Monad.Trans.Class (MonadTrans (..))
 
 import Colog.Core (HasLog (..), LogAction (..), overLogAction)
 
-{- |
+{- | @newtype@ wrapper 'ReaderT' that keeps 'LogAction' in its context.
 -}
 newtype LoggerT msg m a = LoggerT
     { runLoggerT :: ReaderT (LogAction (LoggerT msg m) msg) m a
-    } deriving (Functor, Applicative, Monad, MonadReader (LogAction (LoggerT msg m) msg))
+    } deriving (Functor, Applicative, Monad, MonadIO, MonadReader (LogAction (LoggerT msg m) msg))
 
 instance MonadTrans (LoggerT msg) where
     lift :: Monad m => m a -> LoggerT msg m a

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.7
+resolver: lts-12.9
 
 packages:
   - co-log
@@ -7,6 +7,7 @@ packages:
 extra-deps:
   - base-noprelude-4.11.1.0
   - contravariant-1.5
+  - relude-0.3.0
 
 ghc-options:
   "$locals": -fhide-source-paths


### PR DESCRIPTION
Resolves #7 

I've added `threadDelay` to see whether it actually works for every message individually.

And currently I'm seeing this output:

```haskell
[Warning] Starting application...
[Warning] Starting application...
[Debug] app: First message...
[Debug] app: First message...
[Info] app: Second message...
[Info] app: Second message...
[2018-09-12 06:24:47.695011 UTC] [ThreadId 11] [Warning] Starting application...
[2018-09-12 06:24:47.695011 UTC] [ThreadId 11] [Warning] Starting application...
[2018-09-12 06:24:49.698865 UTC] [ThreadId 11] [Debug] app: First message...
[2018-09-12 06:24:49.698865 UTC] [ThreadId 11] [Debug] app: First message...
[2018-09-12 06:24:49.699671 UTC] [ThreadId 11] [Info] app: Second message...
[2018-09-12 06:24:49.699671 UTC] [ThreadId 11] [Info] app: Second message...
```