### PR TITLE
[#18] Implement extensible message format

### DIFF
--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -38,6 +38,7 @@ library
                      , text
                      , time
                      , transformers >= 0.5
+                     , typerep-map ^>= 0.3.0
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns
@@ -63,6 +64,7 @@ executable play-colog
   build-depends:       base-noprelude
                      , co-log
                      , relude
+                     , typerep-map
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,5 +9,5 @@ extra-deps:
   - contravariant-1.5
   - relude-0.3.0
 
-ghc-options:
-  "$locals": -fhide-source-paths
+  - typerep-map-0.3.0
+  - primitive-0.6.4.0  # needed for typerep-map


### PR DESCRIPTION
Resolves #18 

Dayum. I can't believe it's actually working! And I'm so happy to use `typerep-map` :blush: 

```haskell
[Warning] [Main.app#24] Starting application...
[Warning] [Main.app#24] Starting application...
[Debug]   [Main.example#19] app: First message...
[Debug]   [Main.example#19] app: First message...
[Info]    [Main.example#20] app: Second message...
[Info]    [Main.example#20] app: Second message...
[Info]    [Main.app#28] app: Application finished...
[Info]    [Main.app#28] app: Application finished...
[Warning] [11:54:31.809 13 Sep 2018 UTC] [Main.app#24] [ThreadId 7] Starting application...
[Warning] [11:54:31.809 13 Sep 2018 UTC] [Main.app#24] [ThreadId 7] Starting application...
[Debug]   [11:54:32.813 13 Sep 2018 UTC] [Main.example#19] [ThreadId 7] app: First message...
[Debug]   [11:54:32.813 13 Sep 2018 UTC] [Main.example#19] [ThreadId 7] app: First message...
[Info]    [11:54:32.814 13 Sep 2018 UTC] [Main.example#20] [ThreadId 7] app: Second message...
[Info]    [11:54:32.814 13 Sep 2018 UTC] [Main.example#20] [ThreadId 7] app: Second message...
[Info]    [11:54:32.815 13 Sep 2018 UTC] [Main.app#28] [ThreadId 7] app: Application finished...
[Info]    [11:54:32.815 13 Sep 2018 UTC] [Main.app#28] [ThreadId 7] app: Application finished...
[Warning] [11:54:32.817 13 Sep 2018 UTC] [Main.app#24] Starting application...
[Warning] [11:54:32.817 13 Sep 2018 UTC] [Main.app#24] Starting application...
[Debug]   [11:54:33.819 13 Sep 2018 UTC] [Main.example#19] app: First message...
[Debug]   [11:54:33.819 13 Sep 2018 UTC] [Main.example#19] app: First message...
[Info]    [11:54:33.820 13 Sep 2018 UTC] [Main.example#20] app: Second message...
[Info]    [11:54:33.820 13 Sep 2018 UTC] [Main.example#20] app: Second message...
[Info]    [11:54:33.822 13 Sep 2018 UTC] [Main.app#28] app: Application finished...
[Info]    [11:54:33.822 13 Sep 2018 UTC] [Main.app#28] app: Application finished...
```