### PR TITLE
Export contravariant instance from co-log directly.

### DIFF
--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -39,3 +39,4 @@ library
 
   default-language:    Haskell2010
   default-extensions:  InstanceSigs
+  other-extensions:    CPP

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {- | Implements core data types and combinators for logging actions.
@@ -14,7 +15,7 @@ module Colog.Core.Action
        , cfilter
        , cmap
        , (>$<)
-       , (>$)
+       , (Colog.Core.Action.>$)
        , cmapM
 
          -- * Divisible combinators
@@ -42,6 +43,10 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..), stimesMonoid)
 import Data.Void (Void, absurd)
+
+#if MIN_VERSION_base(4,12,0)
+import Data.Functor.Contravariant (Contravariant (..))
+#endif
 
 ----------------------------------------------------------------------------
 -- Core data type with instances
@@ -312,3 +317,11 @@ infixr 1 <<=
 (<<=) :: Semigroup msg => (LogAction m msg -> m ()) -> LogAction m msg -> LogAction m msg
 (<<=) = extend
 {-# INLINE (<<=) #-}
+
+
+#if MIN_VERSION_base(4,12,0)
+instance Contravariant (LogAction m) where
+    contramap = cmap
+    (>$)      = (Colog.Core.Action.>$)
+
+#endif

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -58,6 +58,7 @@ library
                       OverloadedStrings
                       RecordWildCards
                       TypeApplications
+  other-extensions:   CPP
 
 executable play-colog
   hs-source-dirs:      example

--- a/co-log/src/Colog/Contra.hs
+++ b/co-log/src/Colog/Contra.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- | This module contains 'LogAction' instances of @contravariant@ classes.
@@ -7,16 +8,19 @@ module Colog.Contra
        (
        ) where
 
+#if !MIN_VERSION_base_noprelude(4,12,0)
 import Data.Functor.Contravariant (Contravariant (..))
+#endif
 import Data.Functor.Contravariant.Divisible (Decidable (..), Divisible (..))
 
 import Colog.Core.Action (LogAction)
-
 import qualified Colog.Core.Action as LA
 
+#if !MIN_VERSION_base_noprelude(4,12,0)
 instance Contravariant (LogAction m) where
     contramap = LA.cmap
     (>$)      = (LA.>$)
+#endif
 
 instance (Applicative m) => Divisible (LogAction m) where
     divide  = LA.divide


### PR DESCRIPTION
On GHC-8.6.1 and later we export Contravariant instance
directly from the co-log package, as it does not require
additional dependencies.