### PR TITLE
Adds liftLogIO function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,17 @@ cache:
 matrix:
   include:
 
+  - ghc: 8.2.2
+    env: GHCVER='8.2.2' CABALVER='head'
+    os: linux
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.2.2
+        - cabal-install-head
+
   - ghc: 8.4.3
     env: GHCVER='8.4.3' CABALVER='head'
     os: linux
@@ -25,6 +36,17 @@ matrix:
         - ghc-8.4.3
         - cabal-install-head
 
+  - ghc: 8.6.1
+    env: GHCVER='8.6.1' CABALVER='head'
+    os: linux
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.6.1
+        - cabal-install-head
+
   - ghc: 8.4.3
     env: GHCVER='8.4.3' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
     os: linux
@@ -32,7 +54,6 @@ matrix:
       apt:
         packages:
         - libgmp-dev
-
 
 install:
   - |

--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -4,6 +4,13 @@ Change log
 `co-log-core` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+0.1.1
+=====
+
+* [#46](https://github.com/kowainik/co-log/issues/46):
+  Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
+  `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
+
 0.1.0
 =====
 

--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -10,6 +10,8 @@ The change log is available [on GitHub][2].
 * [#46](https://github.com/kowainik/co-log/issues/46):
   Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
   `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
+* [#48](https://github.com/kowainik/co-log/issues/48)
+  Adds `liftLogIO` function in a new `Colog.Core.IO` module
 
 0.1.0
 =====

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -28,7 +28,6 @@ library
                            Colog.Core.Class
                            Colog.Core.IO
                            Colog.Core.Severity
-                           Colog.Core.IO
 
   build-depends:       base >= 4.10 && < 4.13
 

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -13,7 +13,9 @@ category:            Logging
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md
 cabal-version:       2.0
-tested-with:         GHC == 8.4.3
+tested-with:         GHC == 8.2.2
+                   , GHC == 8.4.3
+                   , GHC == 8.6.1
 
 source-repository head
   type:                git
@@ -26,7 +28,7 @@ library
                            Colog.Core.Class
                            Colog.Core.Severity
 
-  build-depends:       base >= 4.11 && < 5
+  build-depends:       base >= 4.10 && < 4.13
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:     Colog.Core
                            Colog.Core.Action
                            Colog.Core.Class
+                           Colog.Core.IO
                            Colog.Core.Severity
                            Colog.Core.IO
 

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -1,5 +1,5 @@
 name:                co-log-core
-version:             0.1.0
+version:             0.1.1
 description:         Logging library
 synopsis:            Logging library
 homepage:            https://github.com/kowainik/co-log
@@ -27,6 +27,7 @@ library
                            Colog.Core.Action
                            Colog.Core.Class
                            Colog.Core.Severity
+                           Colog.Core.IO
 
   build-depends:       base >= 4.10 && < 4.13
 

--- a/co-log-core/src/Colog/Core.hs
+++ b/co-log-core/src/Colog/Core.hs
@@ -1,9 +1,11 @@
 module Colog.Core
        ( module Colog.Core.Action
        , module Colog.Core.Class
+       , module Colog.Core.IO
        , module Colog.Core.Severity
        ) where
 
 import Colog.Core.Action
 import Colog.Core.Class
+import Colog.Core.IO
 import Colog.Core.Severity

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -3,6 +3,7 @@ module Colog.Core.IO
     , logStringStderr
     , logStringHandle
     , withLogStringFile
+    , liftLogIO
     ) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -31,3 +32,7 @@ Opens file in 'AppendMode'.
 -}
 withLogStringFile :: MonadIO m => FilePath -> (LogAction m String -> IO r) -> IO r
 withLogStringFile path action = withFile path AppendMode $ action . logStringHandle
+
+{- | Lifts a LogAction over IO into a more general Monad. -}
+liftLogIO :: MonadIO m => LogAction IO msg -> LogAction m msg
+liftLogIO (LogAction action) = LogAction (liftIO . action)

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -1,0 +1,33 @@
+module Colog.Core.IO 
+    ( logStringStdout
+    , logStringStderr
+    , logStringHandle
+    , withLogStringFile
+    ) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import System.IO (Handle, IOMode( AppendMode ), hPutStrLn, stderr, withFile)
+import Colog.Core.Action (LogAction (..))
+
+
+{- | Action that prints 'String' to stdout. -}
+logStringStdout :: MonadIO m => LogAction m String
+logStringStdout = LogAction (liftIO . putStrLn)
+
+{- | Action that prints 'String' to stderr. -}
+logStringStderr :: MonadIO m => LogAction m String
+logStringStderr = logStringHandle stderr
+
+{- | Action that prints 'String' to 'Handle'. -}
+logStringHandle :: MonadIO m => Handle -> LogAction m String
+logStringHandle handle = LogAction $ liftIO . hPutStrLn handle
+
+{- | Action that prints 'String' to file. Instead of returning 'LogAction' it's
+implemented in continuation-passing style because it's more efficient to open
+file only once at the start of the application and write to 'Handle' instead of
+opening file each time we need to write to it.
+
+Opens file in 'AppendMode'.
+-}
+withLogStringFile :: MonadIO m => FilePath -> (LogAction m String -> IO r) -> IO r
+withLogStringFile path action = withFile path AppendMode $ action . logStringHandle

--- a/co-log/CHANGELOG.md
+++ b/co-log/CHANGELOG.md
@@ -17,8 +17,7 @@ The change log is available [on GitHub][2].
 * [#37](https://github.com/kowainik/co-log/issues/37):
   Add bounds to all dependencies. Move `Prelude` to the
   `other-modules` section.
-* [#48](https://github.com/kowainik/co-log/issues/48)
-  Adds `liftLogIO` function.
+
 
 0.0.0
 =====

--- a/co-log/CHANGELOG.md
+++ b/co-log/CHANGELOG.md
@@ -4,6 +4,13 @@ Change log
 `co-log uses` [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+0.2.0
+=====
+
+* [#46](https://github.com/kowainik/co-log/issues/46):
+  Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
+  `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
+
 0.1.0
 =====
 

--- a/co-log/CHANGELOG.md
+++ b/co-log/CHANGELOG.md
@@ -17,6 +17,8 @@ The change log is available [on GitHub][2].
 * [#37](https://github.com/kowainik/co-log/issues/37):
   Add bounds to all dependencies. Move `Prelude` to the
   `other-modules` section.
+* [#48](https://github.com/kowainik/co-log/issues/48)
+  Adds `liftLogIO` function.
 
 0.0.0
 =====

--- a/co-log/README.md
+++ b/co-log/README.md
@@ -31,8 +31,10 @@ import Colog (Message, WithLog, cmap, fmtMessage, logDebug, logInfo, logTextStdo
               usingLoggerT)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 
+import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TextIO
+
 ```
 
 ## Simple IO function example

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -23,6 +23,8 @@ library
   hs-source-dirs:      src
   exposed-modules:     Colog
                            Colog.Actions
+                           Colog.Concurrent
+                               Colog.Concurrent.Internal
                            Colog.Contra
                            Colog.Message
                            Colog.Monad
@@ -37,6 +39,7 @@ library
                      , contravariant ^>= 1.5
                      , mtl ^>= 2.2.2
                      , relude ^>= 0.3.0
+                     , stm >= 2.4 && < 2.6
                      , text ^>= 1.2.3
                      , time ^>= 1.9.2
                      , transformers ^>= 0.5

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                co-log
-version:             0.1.0
+version:             0.2.0
 description:         Logging library
 synopsis:            Logging library
 homepage:            https://github.com/kowainik/co-log

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -13,7 +13,9 @@ copyright:           2018 Kowainik
 category:            Logging
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md
-tested-with:         GHC == 8.4.3
+tested-with:         GHC == 8.2.2
+                   , GHC == 8.4.3
+                   , GHC == 8.6.1
 
 source-repository head
   type:                git
@@ -31,7 +33,7 @@ library
                            Colog.Pure
   other-modules:       Prelude
 
-  build-depends:       base-noprelude >= 4.11 && < 5
+  build-depends:       base-noprelude >= 4.10 && < 4.13
                      , ansi-terminal ^>= 0.8
                      , bytestring ^>= 0.10.8
                      , co-log-core ^>= 0.1.0

--- a/co-log/src/Colog/Actions.hs
+++ b/co-log/src/Colog/Actions.hs
@@ -1,12 +1,7 @@
 module Colog.Actions
-       ( -- * 'String' actions
-         logStringStdout
-       , logStringStderr
-       , logStringHandle
-       , withLogStringFile
-
+       (
          -- * 'ByteString' actions
-       , logByteStringStdout
+         logByteStringStdout
        , logByteStringStderr
        , logByteStringHandle
        , withLogByteStringFile
@@ -18,38 +13,10 @@ module Colog.Actions
        , withLogTextFile
        ) where
 
-import System.IO (hPutStrLn)
-
 import Colog.Core.Action (LogAction (..))
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text.IO as TIO
-
-----------------------------------------------------------------------------
--- String
-----------------------------------------------------------------------------
-
-{- | Action that prints 'String' to stdout. -}
-logStringStdout :: MonadIO m => LogAction m String
-logStringStdout = LogAction putStrLn
-
-{- | Action that prints 'String' to stderr. -}
-logStringStderr :: MonadIO m => LogAction m String
-logStringStderr = logStringHandle stderr
-
-{- | Action that prints 'String' to 'Handle'. -}
-logStringHandle :: MonadIO m => Handle -> LogAction m String
-logStringHandle handle = LogAction $ liftIO . hPutStrLn handle
-
-{- | Action that prints 'String' to file. Instead of returning 'LogAction' it's
-implemented in continuation-passing style because it's more efficient to open
-file only once at the start of the application and write to 'Handle' instead of
-opening file each time we need to write to it.
-
-Opens file in 'AppendMode'.
--}
-withLogStringFile :: MonadIO m => FilePath -> (LogAction m String -> IO r) -> IO r
-withLogStringFile path action = withFile path AppendMode $ action . logStringHandle
 
 ----------------------------------------------------------------------------
 -- ByteString

--- a/co-log/src/Colog/Concurrent.hs
+++ b/co-log/src/Colog/Concurrent.hs
@@ -1,0 +1,318 @@
+-- |
+-- For the speed reasons you may want to dump logs asynchronously.
+-- This is especially useful when application threads are CPU
+-- bound while logs emitting is I/O bound. This approach
+-- allows to mitigate bottlenecks from the I/O.
+--
+-- When writing an application user should be aware of the tradeoffs
+-- that concurrent log system can provide, in this module we explain
+-- potential tradeoffs and describe if certain building blocks are
+-- affected or not.
+--
+--   1. Unbounded memory usage - if there is no backpressure mechanism
+--   the user threads, they may generate more logs that can be
+--   written in the same amount of time. In those cases messages will
+--   be accumulated in memory. That will lead to extended GC times and
+--   application may be killed by the operating systems mechanisms.
+--
+--   2. Persistence requirement - sometimes application may want to
+--   ensure that logs were written before it can continue. This is not
+--   a case with concurrent log systems in general, and some logs may
+--   be lost when application exits before dumping all logs.
+--
+--   3. Non-precise logging - sometimes it may happen that there can be
+--   logs reordering (in case if thread was moved to another capability).
+--
+-- In case if your application is a subject of those problems you may
+-- consider not using concurrent logging system in other cases concurrent
+-- logger may be a good default for you.
+--
+module Colog.Concurrent
+       ( -- $general
+         -- * Simple API.
+         -- $simple-api
+         withBackgroundLogger
+       , defCapacity
+         -- * Extended API
+         -- $extended-api
+         -- ** Background worker
+         -- $background-worker
+       , BackgroundWorker
+       , backgroundWorkerWrite
+       , killBackgroundLogger
+         -- ** Background logger
+       , forkBackgroundLogger
+       , convertToLogAction
+         -- ** Worker thread
+         -- $worker-thread 
+       , mkBackgroundThread
+       , runInBackgroundThread
+         -- *** Usage example
+         -- $worker-thread-usage
+       ) where
+
+import Control.Concurrent
+import Control.Concurrent.STM (check)
+import Control.Concurrent.STM.TBQueue
+import Control.Exception (bracket, finally)
+
+import Colog.Core.Action (LogAction (..))
+import Colog.Concurrent.Internal
+
+-- $general
+--
+-- Concurrent logger consists of the basic parts (see schema below).
+--
+--   1. Logger in application thread. This logger is evaluated in the
+--   application thread and has an access to all the context available
+--   in that thread and monad, this logger can work in any `m`.
+--   
+--   2. Communication channel with backpressure support. In addition to
+--   the channel we have a converter that puts the user message to the
+--   communication channel. This converter works in the user thread.
+--   Such a logger usually works in `IO` but it's possible to make it
+--   work in `STM` as well. At this point library provides only `IO`
+--   version, but it can be lifted to any `MonadIO` by the user. 
+--
+--   3. Logger thread. This is the thread that performs actual write to
+--   the sinks. Loggers there do not have access to the users thread
+--   state, unless that state was passed in the message.
+-- 
+-- 
+-- @
+--
+--  +-------------------------+                  +--------------------------------+
+--  |                         |                  | Logger        |   Sink-1       |
+--  |   Application Thread    |                  | Thread    +--->                |
+--  |   -----------------     |  +-----------+   |           |   +----------------+
+--  |                         |  |           |   +---------+ |   +----------------+
+--  |           +-------------+  |  channel  |   | Shared  +----->   Sink-2       |
+--  |           | application||  |          +----> logger  | |   |                |
+--  |           | logger    +----->          |   +---------+ |   +----------------+
+--  |           +-------------+  |           |   |           |   +----------------+
+--  |                         |  +-----------+   |           +--->   Sink3        |
+--  |                         |                  |               |                |
+--  |                         |                  |               +----------------+
+--  |                         |                  |                                |
+--  +-------------------------+                  +--------------------------------+
+-- @
+--
+-- So usually user should write the logging system in the way that all 'LogAction'
+-- that populate and filter information should live in the application logger.
+-- All loggers that do serialization and formatting should live in shared logger.
+--
+--
+-- If more concurrency is needed it's possible to build multilayer systems:
+--
+--
+-- @
+--   +-------------+                         +-------+
+--   | application |---+                 +---| sink-1|
+--   +-------------+   |   +---------+   |   +-------+
+--                     +---| logger  |---+
+--                         +---------+   |   +-------+
+--                                       +---| sink-2|
+--                                           +-------+
+-- @
+-- 
+-- In this approach application will be concurrently write logs to the logger, then
+-- logger will be concurrently writing to all sinks.
+
+
+-- $simple-api
+--
+-- Simple API provides a handy easy to use API that can be used directly
+-- in application without dealing with internals. Based on users feedback
+-- internal implementation of the simple API may change, especially in early
+-- versions of the library. But the guarantee that we give is that no matter
+-- what implementation is it will be kept with reasonable defaults and will
+-- be applicable to a generic application.
+--
+
+-- | An exception safe way to create background logger.  This method will fork
+-- a thread that will run 'shared worker', see schema above. 
+--
+-- @Capacity@ - provides a backpressure mechanism and tells how many messages
+-- in flight are allowed. In most cases 'defCapacity' will work well.
+-- See 'forkBackgroundLogger' for more details.
+--
+-- @LogAction@ - provides a logger action, this action does not have access to the
+-- application state or thread info, so you should only pass methods that serialize
+-- and dump data there.
+--
+-- @ 
+-- import qualified Data.Aeson as Aeson
+--
+-- main :: IO ()
+-- main =
+--   'withBackgroundLogger'
+--      'defCapacity'
+--      (Aeson.encode \``Colog.Core.Action.cmap`\` logger)
+--      $ 'Colog.Monad.usingLoggerT' $ __do__
+--         'Colog.Monad.logMsg' "Starting application..."
+--   where
+--     logger = 'Colog.Action.withLogByteStringFile' "\/var\/log\/myapp\/log"
+-- @
+withBackgroundLogger :: MonadIO m => Capacity -> LogAction IO msg -> (LogAction m msg -> IO a) -> IO a
+withBackgroundLogger cap logger action =
+   bracket (forkBackgroundLogger cap logger)
+           (killBackgroundLogger)
+           (action . convertToLogAction)
+
+-- | Default capacity size, (4096)
+defCapacity :: Capacity
+defCapacity = Capacity 4096
+ 
+
+-- $extended-api
+-- Extended API explains how asynchronous logging is working and provides basic
+-- building blocks for writing your own combinators. This is the part of the public
+-- API and will not change without prior notice.
+
+-- $background-worker
+-- The main abstraction for the concurrent worker is 'BackgroundWorker'. This
+-- is a wrapper of the thread, that has communication channel to talk to, and threadId.
+-- 
+-- Background worker may provide a backpressure mechanism, but does not provide
+-- notification of completeness unless it's included in the message itself.
+
+
+-- | Stop background logger thread.
+--
+-- The thread is blocked until background thread will finish processing
+-- all messages that were written in the channel.
+killBackgroundLogger :: BackgroundWorker msg -> IO ()
+killBackgroundLogger bl = do
+  killThread (backgroundWorkerThreadId bl)
+  atomically $ readTVar (backgroundWorkerIsAlive bl) >>= check . not
+
+-- $background-logger
+--
+-- Background logger is specialized version of the 'BackgroundWorker' process.
+-- Instead of running any job it will accept @msg@ type
+-- instead and process it with a single logger defined at creation time.
+
+-- | Creates background logger with given @Capacity@,
+-- takes a 'LogAction' that should describe how to write
+-- logs.
+--
+-- @capacity@ - parameter tells how many in flight messages are allowed,
+-- if that value is reached then user's thread that emits logs will be
+-- blocked until any message will be written. Usually if value should be
+-- chosen reasonably high and if this value is reached it means that
+-- the application environment experience severe problems.
+--
+-- __N.B.__ The 'LogAction' will be run in the background
+-- thread so that logger should not add any thread specific
+-- context to the message.
+--
+-- __N.B.__ On exit, even in case of exception thread will dump all values
+-- that are in the queue. But it will stop doing that in case if another
+-- exception will happen.
+forkBackgroundLogger :: Capacity -> LogAction IO msg -> IO (BackgroundWorker msg)
+forkBackgroundLogger (Capacity cap) logAction = do
+  queue <- newTBQueueIO cap
+  isAlive <- newTVarIO True
+  tid <- forkFinally
+    (forever $ do
+      msg <- atomically $ readTBQueue queue
+      unLogAction logAction msg)
+    (\_ ->
+       (do msgs <- atomically $ many $ readTBQueue queue
+           for_ msgs $ unLogAction logAction)
+         `finally` (atomically $ writeTVar isAlive False))
+  pure $ BackgroundWorker tid (writeTBQueue queue) isAlive
+
+
+-- | Convert a given 'BackgroundWorker msg' into a 'LogAction msg'
+-- that will send log message to the background thread,
+-- without blocking the thread.
+--
+-- If logger dies for any reason then thread that emits
+-- logs will receive 'BlockedIndefinitelyOnSTM' exception.
+--
+-- You can extend result worker with all functionality available
+-- with co-log. This logger will have an access to the thread
+-- state.
+convertToLogAction :: MonadIO m => BackgroundWorker msg -> LogAction m msg
+convertToLogAction logger = LogAction $ \msg ->
+  liftIO $ atomically $ backgroundWorkerWrite logger msg
+  
+-- $worker-thread
+-- While generic background logger is enough for the most
+-- of the usecases, sometimes you may want even more.
+--
+-- There are at least two cases where that may happen:
+--
+--   1. You need to modify logger, for example different
+--   threads wants to write to different sources. Or you
+--   want to change lgo mechanism in runtime.
+--   
+--   2. You may want to implement some notification
+--   machinery that allows you to guarantee that your
+--   logs were written before processing further.
+--
+-- In order to solve those problems worker thread abstraction
+-- was introduced. This is a worker that accepts any action
+-- and performs that.
+
+-- | Create a background worker with a given capacity.
+-- If capacity is reached, then the thread that tries to
+-- write logs will be blocked.
+--
+-- This method is more generic than 'forkBackgroundLogger' but
+-- it's less effective, as you have to pass entire closure to
+-- be run and that leads to extra memory usage and indirect calls
+-- happening.
+--
+-- When closed it will dump all pending messages, unless
+-- another asynchronous exception will arrive, or synchronous
+-- exception will happen during the logging.
+mkBackgroundThread :: Capacity -> IO (BackgroundWorker (IO ()))
+mkBackgroundThread (Capacity cap) = do
+  queue <- newTBQueueIO cap
+  isAlive <- newTVarIO True
+  tid <- forkFinally 
+    (forever $ join $ atomically $ readTBQueue queue)
+    (\_ ->
+       (sequence_ =<< (atomically $ many $ readTBQueue queue))
+       `finally` (atomically $ writeTVar isAlive False))
+  pure $ BackgroundWorker tid (writeTBQueue queue) isAlive
+
+-- | Run logger action asynchronously in the worker thread.
+-- Logger is executed in the other thread entirely, so if
+-- logger takes any thread related context it will be
+-- read from the other thread.
+runInBackgroundThread :: BackgroundWorker (IO ()) -> LogAction IO msg -> LogAction IO msg
+runInBackgroundThread bt logAction = LogAction $ \msg -> do
+  atomically $ backgroundWorkerWrite bt $ unLogAction logAction msg
+
+-- $worker-thread-usage
+--
+-- Consider following example. (Leaving resource control aside).
+--
+-- @
+-- data M msg = M (MVar ()) msg
+--
+-- notificationLogger :: MonadIO m => LoggerAction m msg -> LoggerAction m (M msg)
+-- notificationLogger logger = 'LoggerAction' $ \(M lock msg) ->
+--    (unLogger logger msg) `finally` (putMVar lock ())
+-- 
+-- example = __do__
+--    worker <- 'mkBackgroundWorker' 'defCapacity'
+--    lock <- newEmptyMVar
+--    -- Log message with default logger.
+--    'unLogger'
+--       ('runInBackgroundThread' worker 
+--       (notificationLogger $ 'Colog.Action.withLogByteStringFile' "\/var\/log\/myapp\/log")
+--       (M lock "my message") 
+--    -- Log message with a different logger.
+--    'unLogger'
+--       ('runInBackgroundThread' worker 
+--       ('Colog.Action.withLogByteStringFile' "/var/log/myapp/log")
+--       ("another message") 
+--    -- Block until first message is logged.
+--    _ <- takeMVar lock
+-- @
+--
+

--- a/co-log/src/Colog/Concurrent/Internal.hs
+++ b/co-log/src/Colog/Concurrent/Internal.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+-- |
+--
+-- This is internal module, use it on your own risk.
+-- The implementation here may be changed without a
+-- version bump.
+module Colog.Concurrent.Internal
+       ( BackgroundWorker(..)
+       , Capacity(..)
+       ) where
+
+import Control.Concurrent
+
+-- | A wrapper type that carries capacity. The internal
+-- type may be differrent for the different GHC versions.
+#if MIN_VERSION_stm(2,5,0)
+newtype Capacity = Capacity Natural
+#else
+newtype Capacity = Capacity Int
+#endif
+
+-- | Wrapper for the background thread that may
+-- receive messages to process.
+data BackgroundWorker msg = BackgroundWorker
+  { backgroundWorkerThreadId :: !ThreadId
+    -- ^ Background 'ThreadId'.
+  , backgroundWorkerWrite :: msg -> STM ()
+    -- ^ Method for communication with the thread.
+  , backgroundWorkerIsAlive :: TVar Bool
+  }

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE CPP                   #-}
 
 {- | 'Message' with 'Severity', and logging functions for them.
 -}
@@ -165,7 +166,12 @@ newtype MessageField (m :: Type -> Type) (fieldName :: Symbol) where
 
 instance (KnownSymbol fieldName, a ~ m (FieldType fieldName))
       => IsLabel fieldName (a -> TM.WrapTypeable (MessageField m)) where
+#if MIN_VERSION_base_noprelude(4,11,0)
     fromLabel field = TM.WrapTypeable $ MessageField @fieldName field
+#else
+    fromLabel field = TM.WrapTypeable $ MessageField  @_ @fieldName field    
+#endif
+    {-# INLINE fromLabel #-}
 
 extractField
     :: Applicative m

--- a/co-log/src/Colog/Monad.hs
+++ b/co-log/src/Colog/Monad.hs
@@ -13,7 +13,6 @@ module Colog.Monad
        ) where
 
 import Control.Monad.Reader (MonadReader (..), ReaderT)
-import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Class (MonadTrans (..))
 
 import Colog.Core (HasLog (..), LogAction (..), overLogAction)
@@ -65,9 +64,6 @@ withLog = local . overLogAction
 
 liftLogAction :: (Monad m, MonadTrans t) => LogAction m msg -> LogAction (t m) msg
 liftLogAction (LogAction action) = LogAction (lift . action)
-
-liftLogIO :: MonadIO m => LogAction IO msg -> LogAction m msg
-liftLogIO (LogAction action) = LogAction (liftIO . action)
 
 {- | Runner for 'LoggerT' monad. Let's consider one simple example of monadic
 action you have:

--- a/co-log/src/Colog/Monad.hs
+++ b/co-log/src/Colog/Monad.hs
@@ -13,6 +13,7 @@ module Colog.Monad
        ) where
 
 import Control.Monad.Reader (MonadReader (..), ReaderT)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Class (MonadTrans (..))
 
 import Colog.Core (HasLog (..), LogAction (..), overLogAction)
@@ -64,6 +65,9 @@ withLog = local . overLogAction
 
 liftLogAction :: (Monad m, MonadTrans t) => LogAction m msg -> LogAction (t m) msg
 liftLogAction (LogAction action) = LogAction (lift . action)
+
+liftLogIO :: MonadIO m => LogAction IO msg -> LogAction m msg
+liftLogIO (LogAction action) = LogAction (liftIO . action)
 
 {- | Runner for 'LoggerT' monad. Let's consider one simple example of monadic
 action you have:


### PR DESCRIPTION
Resolves #48.

As per my comment in that issue, this adds `liftLogIO` right next to `liftLogAction` in `Colog.Monad`.

I wasn't sure if this would need a version bump, so I added the changes under "0.1.0" otherwise this addition can go in the next minor.