### PR TITLE
Actually exports the liftLogIO function

### DIFF
--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -3,6 +3,7 @@ module Colog.Core.IO
     , logStringStderr
     , logStringHandle
     , withLogStringFile
+    , liftLogIO
     ) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)


### PR DESCRIPTION
In the previous merge we added the `liftLogIO` function, but didn't actually export it. It's probably better if we do export it though...