### PR TITLE
[#49] Adds and exports (<&) and (&>) comibinators for LogAction

### DIFF
--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -12,6 +12,8 @@ The change log is available [on GitHub][2].
   `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
 * [#48](https://github.com/kowainik/co-log/issues/48)
   Adds `liftLogIO` function.
+* [#49](https://github.com/kowainik/co-log/issues/49)
+  Adds `<&` and `&>`operators for `unLogAction`.
 
 
 0.1.0

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -122,13 +122,27 @@ Note that because of the types, something like:
 > action <& msg1 <& msg2
 doesn't make sense. Instead you want:
 > action <& msg1 >> action <& msg2
+
+In addition, because '<&' has higher precedence
+than the other operators in this module,
+the following:
+> f >$< action <& msg
+should be replaced by
+> (f >$< action) <& msg
+
 -}
 infix 5 <&
 (<&) :: LogAction m msg -> msg -> m ()
 (<&) = coerce
 {-# INLINE (<&) #-}
 
--- | A flipped version of '<&'
+{- | A flipped version of '<&'
+
+It shares the same precedence as '<&',
+so make sure to surround lower precedence
+operators in parentheses:
+> (f >$< action) <& msg
+-}
 infix 5 &>
 (&>) :: msg -> LogAction m msg -> m ()
 (&>) = flip unLogAction

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP          #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {- | Implements core data types and combinators for logging actions.

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -126,7 +126,7 @@ infix 5 <&
 (<&) :: LogAction m msg -> msg -> m ()
 (<&) = unLogAction
 
--- | A flipped version of <&
+-- | A flipped version of '<&'
 infix 5 &>
 (&>) :: msg -> LogAction m msg -> m ()
 (&>) = flip unLogAction

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -7,6 +7,8 @@
 module Colog.Core.Action
        ( -- * Core type and instances
          LogAction (..)
+        , (<&)
+        , (&>)
 
          -- * 'Semigroup' combinators
        , foldActions
@@ -111,6 +113,23 @@ instance Applicative m => Monoid (LogAction m a) where
     mconcat :: [LogAction m a] -> LogAction m a
     mconcat = foldActions
     {-# INLINE mconcat #-}
+
+
+{- | Operator version of 'unLogAction'
+
+Note that because of the types, something like:
+> action <& msg1 <& msg2
+doesn't make sense. Instead you want:
+> action <& msg1 >> action <& msg2
+-}
+infix 5 <&
+(<&) :: LogAction m msg -> msg -> m ()
+(<&) = unLogAction
+
+-- | A flipped version of <&
+infix 5 &>
+(&>) :: msg -> LogAction m msg -> m ()
+(&>) = flip unLogAction
 
 ----------------------------------------------------------------------------
 -- Combinators

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -125,11 +125,13 @@ doesn't make sense. Instead you want:
 infix 5 <&
 (<&) :: LogAction m msg -> msg -> m ()
 (<&) = unLogAction
+{-# INLINE (<&) #-}
 
 -- | A flipped version of '<&'
 infix 5 &>
 (&>) :: msg -> LogAction m msg -> m ()
 (&>) = flip unLogAction
+{-# INLINE (&>) #-}
 
 ----------------------------------------------------------------------------
 -- Combinators

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -40,6 +40,7 @@ module Colog.Core.Action
        ) where
 
 import Control.Monad (when, (>=>))
+import Data.Coerce (coerce)
 import Data.Foldable (for_)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Monoid (Monoid (..))
@@ -124,7 +125,7 @@ doesn't make sense. Instead you want:
 -}
 infix 5 <&
 (<&) :: LogAction m msg -> msg -> m ()
-(<&) = unLogAction
+(<&) = coerce
 {-# INLINE (<&) #-}
 
 -- | A flipped version of '<&'

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -129,7 +129,6 @@ the following:
 > f >$< action <& msg
 should be replaced by
 > (f >$< action) <& msg
-
 -}
 infix 5 <&
 (<&) :: LogAction m msg -> msg -> m ()
@@ -141,7 +140,7 @@ infix 5 <&
 It shares the same precedence as '<&',
 so make sure to surround lower precedence
 operators in parentheses:
-> (f >$< action) <& msg
+> msg &> (f >$< action)
 -}
 infix 5 &>
 (&>) :: msg -> LogAction m msg -> m ()

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -7,8 +7,8 @@
 module Colog.Core.Action
        ( -- * Core type and instances
          LogAction (..)
-        , (<&)
-        , (&>)
+       , (<&)
+       , (&>)
 
          -- * 'Semigroup' combinators
        , foldActions


### PR DESCRIPTION
Resolves #49 

Adds 2 operator versions of `unLogAction`. I've given both of them a precedence of 5, so that they're higher than the other combinators, so that things like:
```haskell
f >$< log <& msg
```
have to be written as:
```haskell
(f >$< log) <& msg
```
The infixity should also be > 2 to be higher than the monad operators `>>` and `>>=`, so that
we can do things like:
```haskell
msg &> action >> msg &> action
```

Because something like
```haskell
action <& msg <& msg
```
doesn't make sense in terms of the types, I haven't added infixr or infixl.