### PR TITLE
[#59] Removes unnecessary time extra-dep, fixing stack test

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ extra-deps:
   - base-noprelude-4.11.1.0
   - contravariant-1.5
   - relude-0.3.0
-  - time-1.9.2
 
   - typerep-map-0.3.0
   - primitive-0.6.4.0  # needed for typerep-map


### PR DESCRIPTION
This should resolve #59. I've tested this on my machine (linux, ghc 8.4.3) hopefully the CI agrees.