### PR TITLE
Introduce basic benchmarks of the library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,6 @@ script:
     else
       stack build co-log-core --test --bench --no-run-benchmarks --no-terminal
       stack build co-log      --test --bench --no-run-benchmarks --no-terminal
-      stack build co-log-benchmark --test --bench --no-run-benchmarks --no-terminal
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ script:
     else
       stack build co-log-core --test --bench --no-run-benchmarks --no-terminal
       stack build co-log      --test --bench --no-run-benchmarks --no-terminal
+      stack build co-log-benchmark --test --bench --no-run-benchmarks --no-terminal
     fi
 
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,1 @@
-packages: co-log-core/ co-log/
+packages: co-log-core/ co-log/ co-log-benchmark/

--- a/co-log-benchmark/ChangeLog.md
+++ b/co-log-benchmark/ChangeLog.md
@@ -1,0 +1,5 @@
+# Revision history for y
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/co-log-benchmark/LICENSE
+++ b/co-log-benchmark/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Alexander Vershilov
+Copyright (c) Kowainik
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/co-log-benchmark/LICENSE
+++ b/co-log-benchmark/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018 Alexander Vershilov
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/co-log-benchmark/Main.hs
+++ b/co-log-benchmark/Main.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main
+  ( main
+  ) where
+
+import Data.Time.Clock
+import Colog
+import Control.Monad
+import Control.Exception
+import Data.Foldable
+import System.Environment
+import System.IO
+import System.Process.Typed
+import System.Posix.Process
+import qualified Data.Text.Encoding
+import GHC.Stack
+import Text.Printf
+
+
+-- | List of benchmarks.
+benchs :: [(String, IO ())]
+benchs =
+  [("baseline", run (LogAction (\_ -> pure ())) ["message"::String])
+  ,("stdout<string",
+     let la = logStringStdout 
+     in run la ["message"])
+  ,("stdout<text",
+     let la = logTextStdout
+     in run la ["message"])
+  ,("stdout<bytestring",
+     let la = logByteStringStdout 
+     in run la ["message"])
+  ,("stderr<bytestring",
+     let la = logByteStringStderr 
+     in run la ["message"])
+  ,("{stdout<>stderr}<bytestring",
+     let la = logByteStringStdout <> logByteStringStderr
+     in run la ["message"])
+  ,("stdout<format<message",
+     let la = cmap fmtMessage logTextStdout
+     in run la [Message D emptyCallStack "message"])
+  ,("stdout<format<message{with callstack}",
+     let la = cmap fmtMessage logTextStdout
+     in run la [Message D callStack "message"])
+  ,("stdout<format<message{with callstack:5}",
+     let la = cmap fmtMessage logTextStdout
+     in nest 5 $ run la [Message D callStack "message"])
+  ,("stdout<format<message{with callstack:50}",
+     let la = cmap fmtMessage logTextStdout
+     in nest 50 $ run la [Message D callStack "message"])
+  ,("stdout<bytestring<format<message",
+     let la = fmtMessage
+            `cmap` (Data.Text.Encoding.encodeUtf8
+                    `cmap` logByteStringStdout)
+     in run la [Message D emptyCallStack "message"])
+  ,("stdout<bytestring<rich-message<upgrade<message",
+     let la = 
+            (Data.Text.Encoding.encodeUtf8
+                    `cmap` logByteStringStdout)
+         richMessageAction  = cmapM fmtRichMessageDefault la
+         semiMessageAction = upgradeMessageAction
+                                defaultFieldMap
+                                richMessageAction
+     in run semiMessageAction [Message D emptyCallStack "message"])
+  ]
+  where
+    run :: LogAction IO a -> [a] -> IO ()
+    run la msgs = do
+      replicateM_ 10000 $ traverse_ (unLogAction la) msgs
+    nest :: HasCallStack => Int -> IO a -> IO a
+    nest 0 f = f
+    nest n f = (nest (n-1) f) `onException` (pure ()) -- force nesting
+
+main :: IO ()
+main = getArgs >>= \case
+  [] -> do
+     putStrLn "Dump 10k messages (in a forked process):"
+     for_ benchs $ \(name, _) -> do
+       t <- timeProcess name
+       printf "%-50s %s\n" name (show t)
+  (name:_) -> case name `lookup` benchs of
+     Nothing -> pure ()
+     Just f  -> f
+
+-- | Measure the running time of the process.
+-- The process allowed to dump data to stdout or /dev/null.
+-- We measure the total running time of the process, and
+-- do not verify that all logs were actually dumped, process
+-- should do that on it's own.
+timeProcess :: String -> IO NominalDiffTime
+timeProcess n = do
+  t <- getCurrentTime
+  pid <- getProcessID 
+  withFile "/dev/null" AppendMode $ \fnull1 -> do
+    withFile "/dev/null" AppendMode $ \fnull2 -> do
+      let cfg = setStdin  closed
+              $ setStdout (useHandleClose fnull1)
+              $ setStderr (useHandleClose fnull2)
+              $ proc ("/proc/" ++ show pid ++ "/exe") [n]
+      runProcess_ cfg
+  t' <- getCurrentTime
+  pure $ t' `diffUTCTime` t

--- a/co-log-benchmark/Main.hs
+++ b/co-log-benchmark/Main.hs
@@ -9,6 +9,7 @@ import Colog
 import Control.Monad
 import Control.Exception
 import Data.Foldable
+import Data.Semigroup ((<>))
 import System.Environment
 import System.IO
 import System.Process.Typed
@@ -16,6 +17,7 @@ import System.Posix.Process
 import qualified Data.Text.Encoding
 import GHC.Stack
 import Text.Printf
+import Prelude
 
 
 -- | List of benchmarks.

--- a/co-log-benchmark/Main.hs
+++ b/co-log-benchmark/Main.hs
@@ -21,7 +21,7 @@ import Text.Printf
 -- | List of benchmarks.
 benchs :: [(String, IO ())]
 benchs =
-  [("baseline", run (LogAction (\_ -> pure ())) ["message"::String])
+  [("baseline", run mempty ["message"::String])
   ,("stdout<string",
      let la = logStringStdout 
      in run la ["message"])

--- a/co-log-benchmark/Setup.hs
+++ b/co-log-benchmark/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/co-log-benchmark/co-log-benchmark.cabal
+++ b/co-log-benchmark/co-log-benchmark.cabal
@@ -23,7 +23,7 @@ executable co-log-features-bench
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.11 && <4.12,
+  build-depends:       base >=4.10 && <4.13,
                        co-log,
                        text,
                        time,

--- a/co-log-benchmark/co-log-benchmark.cabal
+++ b/co-log-benchmark/co-log-benchmark.cabal
@@ -1,0 +1,32 @@
+name:                co-log-benchmark
+version:             0.1.0.0
+synopsis:            benchmarks of the co-log library
+description:         Set of benchmarks that can be used to verify
+                     that colog library does not introduce unnesessarily
+                     overhead for your use-case. And check that colog
+                     library behaves on par with other frameworks.
+license:             MPL-2.0
+license-file:        LICENSE
+author:              Alexander Vershilov
+-- maintainer:          alexander.vershilov@gmail.com
+copyright:           2018 Kowainik
+category:            Logging
+build-type:          Simple
+extra-source-files:  CHANGELOG.md
+cabal-version:       >=1.10
+
+source-repository    head
+  type:              git
+  location:          https://github.com/kowainik/co-log.git
+
+executable co-log-features-bench
+  main-is:             Main.hs
+  -- other-modules:
+  -- other-extensions:
+  build-depends:       base >=4.11 && <4.12,
+                       co-log,
+                       text,
+                       time,
+                       typed-process,
+                       unix
+  default-language:    Haskell2010

--- a/co-log-benchmark/co-log-benchmark.cabal
+++ b/co-log-benchmark/co-log-benchmark.cabal
@@ -8,7 +8,6 @@ description:         Set of benchmarks that can be used to verify
 license:             MPL-2.0
 license-file:        LICENSE
 author:              Alexander Vershilov
--- maintainer:          alexander.vershilov@gmail.com
 copyright:           2018 Kowainik
 category:            Logging
 build-type:          Simple
@@ -23,10 +22,11 @@ executable co-log-features-bench
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.10 && <4.13,
+  build-depends:       base-noprelude >=4.10 && <4.13,
                        co-log,
                        text,
                        time,
                        typed-process,
+                       relude,
                        unix
   default-language:    Haskell2010

--- a/co-log-benchmark/co-log-benchmark.cabal
+++ b/co-log-benchmark/co-log-benchmark.cabal
@@ -8,6 +8,7 @@ description:         Set of benchmarks that can be used to verify
 license:             MPL-2.0
 license-file:        LICENSE
 author:              Alexander Vershilov
+-- maintainer:          alexander.vershilov@gmail.com
 copyright:           2018 Kowainik
 category:            Logging
 build-type:          Simple
@@ -22,11 +23,10 @@ executable co-log-features-bench
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base-noprelude >=4.10 && <4.13,
+  build-depends:       base >=4.10 && <4.13,
                        co-log,
                        text,
                        time,
                        typed-process,
-                       relude,
                        unix
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-12.9
 packages:
   - co-log
   - co-log-core
+  - co-log-benchmark
 
 extra-deps:
   - base-noprelude-4.11.1.0


### PR DESCRIPTION
Introduce basic benchmarks of the log mechanism that allows
testing the overhead of the each feature added.

Example output:
```
Dump 10k messages (in a forked process):
baseline                                           0.001114674s
stdout<string                                      0.005194026s
stdout<text                                        0.004967748s
stdout<bytestring                                  0.002918046s
stderr<bytestring                                  0.01753503s
{stdout<>stderr}<bytestring                        0.017461043s
stdout<format<message                              0.009314225s
stdout<format<message{with callstack}              0.009744045s
stdout<format<message{with callstack:5}            0.018102189s
stdout<format<message{with callstack:50}           0.018013676s
stdout<bytestring<format<message                   0.009570143s
stdout<bytestring<rich-message<upgrade<message     0.134770134s
```
Currently benchmarks are implemented outside of the main
application as I had trouble to make `cabal new-configure` find
the build plan without `--allow-newer`. Also these benchmarks
may introduce dependencies on the other logging libraries in the
future.

At this point of time only the simplest benchmarks were introduced.
This benchmarks are testing sequencial dump of the logs with different
features added atop. Theoretically current benchmarks may be moved
to the application and criterion can be used for measuring time.
However I planned to make more long running benchmarks where criterion
may not shine, and such benchmarks may make CI time much larger for
not purpose.