### PR TITLE
Omit last PureLogger parameter

### DIFF
--- a/co-log/src/Colog/Pure.hs
+++ b/co-log/src/Colog/Pure.hs
@@ -27,7 +27,7 @@ runPureLogT :: Functor m => PureLoggerT msg m a -> m (a, [msg])
 runPureLogT = fmap (second toList) . usingStateT mempty . runPureLoggerT
 
 -- | 'PureLoggerT' specialized to 'Identity'
-type PureLogger msg a = PureLoggerT msg Identity a
+type PureLogger msg = PureLoggerT msg Identity
 
 -- | Returns result value of 'PureLogger' and list of logged messages.
 runPureLog :: PureLogger msg a -> (a, [msg])


### PR DESCRIPTION
You're not able to use `LoggerT msg (PureLogger msg) a` since it is not possible to use partial applied type synonyms. However, omitting last parameter helps.