### PR TITLE
[#63] Add `logPrint` and `logPrintStderr` to Colog.Core.IO.

### DIFF
--- a/co-log-benchmark/Main.hs
+++ b/co-log-benchmark/Main.hs
@@ -24,6 +24,9 @@ import Prelude
 benchs :: [(String, IO ())]
 benchs =
   [("baseline", run mempty ["message"::String])
+  ,("stdout<print",
+     let la = logPrint
+     in run la [5])
   ,("stdout<string",
      let la = logStringStdout 
      in run la ["message"])

--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -7,6 +7,8 @@ The change log is available [on GitHub][2].
 0.1.1
 =====
 
+* [#63](https://github.com/kowainik/co-log/issues/63)
+  Add `logPrint` and `logPrintStderr` to Colog.Core.IO
 * [#46](https://github.com/kowainik/co-log/issues/46):
   Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
   `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -1,5 +1,7 @@
 module Colog.Core.IO 
-    ( logStringStdout
+    ( logPrint
+    , logPrintStderr
+    , logStringStdout
     , logStringStderr
     , logStringHandle
     , withLogStringFile
@@ -7,8 +9,24 @@ module Colog.Core.IO
     ) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import System.IO (Handle, IOMode( AppendMode ), hPutStrLn, stderr, withFile)
+import System.IO (Handle, IOMode( AppendMode ), hPrint, hPutStrLn, stderr, withFile)
 import Colog.Core.Action (LogAction (..))
+
+{- | Action that prints to stdout using 'Show'.
+
+>>> unLogAction logPrint 5
+5
+-}
+logPrint :: (Show s, MonadIO m) => LogAction m s
+logPrint = LogAction (liftIO . print)
+
+{- | Action that prints to stderr using 'Show'.
+
+>>> unLogAction logPrintStderr 5
+5
+-}
+logPrintStderr :: (Show s, MonadIO m) => LogAction m s
+logPrintStderr = LogAction (liftIO . hPrint stderr)
 
 {- | Action that prints 'String' to stdout.
 

--- a/co-log/example/Main.hs
+++ b/co-log/example/Main.hs
@@ -14,9 +14,9 @@ import Control.Concurrent (threadDelay)
 
 import Colog (pattern D, LogAction, Message (..), PureLogger, WithLog, cmapM, cmap, defaultFieldMap,
               fmtMessage, fmtRichMessageDefault, log, logException, logInfo, logMessagePure, logMsg,
-              logMsgs, logStringStdout, logTextStderr, logTextStdout, logWarning, runPureLog,
-              upgradeMessageAction, usingLoggerT, withLog, withLogTextFile, (*<), (>$), (>$<), (>*),
-              (>*<), (>|<))
+              logMsgs, logPrint, logStringStdout, logTextStderr, logTextStdout, logWarning,
+              runPureLog, upgradeMessageAction, usingLoggerT, withLog, withLogTextFile, (*<), (>$),
+              (>$<), (>*), (>*<), (>|<))
 
 import qualified Data.TypeRepMap as TM
 
@@ -72,16 +72,12 @@ carToTuple (Car make model engine) = (make, (model, engine))
 stringL :: LogAction IO String
 stringL = logStringStdout
 
--- Combinator that allows to log any showable value
-showL :: Show a => LogAction IO a
-showL = cmap show stringL
-
 -- Returns log action that logs given string ignoring its input.
 constL :: String -> LogAction IO a
 constL s = s >$ stringL
 
 intL :: LogAction IO Int
-intL = showL
+intL = logPrint
 
 -- log actions that logs single car module
 carL :: LogAction IO Car


### PR DESCRIPTION
Resovles  #63:

Added the suggested `logPrint` and `logPrintStderr`.
Updated the benchmarks to test `logPrint`.
Updated example to use the new functions.