### PR TITLE
Use standard extensions in co-log

### DIFF
--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -41,8 +41,17 @@ library
                        -freverse-errors
 
   default-language:    Haskell2010
-  default-extensions:  InstanceSigs
-  other-extensions:    CPP
+  default-extensions:  ConstraintKinds
+                       DeriveGeneric
+                       GeneralizedNewtypeDeriving
+                       LambdaCase
+                       OverloadedStrings
+                       RecordWildCards
+                       ScopedTypeVariables
+                       StandaloneDeriving
+                       TupleSections
+                       TypeApplications
+                       ViewPatterns
 
 test-suite doctest
   build-depends:        base, doctest ^>= 0.16.0

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP          #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE InstanceSigs #-}
 
 {- | Implements core data types and combinators for logging actions.
 -}

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -57,13 +57,17 @@ library
                        -freverse-errors
 
   default-language:   Haskell2010
-  default-extensions: DeriveGeneric
-                      GeneralizedNewtypeDeriving
-                      InstanceSigs
-                      OverloadedStrings
-                      RecordWildCards
-                      TypeApplications
-  other-extensions:   CPP
+  default-extensions:  ConstraintKinds
+                       DeriveGeneric
+                       GeneralizedNewtypeDeriving
+                       LambdaCase
+                       OverloadedStrings
+                       RecordWildCards
+                       ScopedTypeVariables
+                       StandaloneDeriving
+                       TupleSections
+                       TypeApplications
+                       ViewPatterns
 
 executable play-colog
   hs-source-dirs:      example

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -3,12 +3,10 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE ViewPatterns          #-}
 {-# LANGUAGE CPP                   #-}
 
 {- | 'Message' with 'Severity', and logging functions for them.

--- a/co-log/src/Colog/Monad.hs
+++ b/co-log/src/Colog/Monad.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE InstanceSigs        #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Colog.Monad
        ( LoggerT (..)


### PR DESCRIPTION
Resolves #69.

Uses the standard extensions for kowainik, as mentioned in that issue, and removes unnecessary per file extensions when necessary.