### PR TITLE
[#13] Improve documentation and description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,30 +25,30 @@ matrix:
         - ghc-8.2.2
         - cabal-install-head
 
-  - ghc: 8.4.3
-    env: GHCVER='8.4.3' CABALVER='head'
+  - ghc: 8.4.4
+    env: GHCVER='8.4.4' CABALVER='head'
     os: linux
     addons:
       apt:
         sources:
         - hvr-ghc
         packages:
-        - ghc-8.4.3
+        - ghc-8.4.4
         - cabal-install-head
 
-  - ghc: 8.6.1
-    env: GHCVER='8.6.1' CABALVER='head'
+  - ghc: 8.6.2
+    env: GHCVER='8.6.2' CABALVER='head'
     os: linux
     addons:
       apt:
         sources:
         - hvr-ghc
         packages:
-        - ghc-8.6.1
+        - ghc-8.6.2
         - cabal-install-head
 
-  - ghc: 8.4.3
-    env: GHCVER='8.4.3' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+  - ghc: 8.4.4
+    env: GHCVER='8.4.4' STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
     os: linux
     addons:
       apt:
@@ -75,7 +75,7 @@ install:
 script:
   - |
     if [ -z "$STACK_YAML" ]; then
-       cabal new-test co-log-core
+       cabal new-test all
     else
       stack build co-log-core --test --bench --no-run-benchmarks --no-terminal
       stack build co-log      --test --bench --no-run-benchmarks --no-terminal

--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -1,25 +1,27 @@
-Change log
-==========
+# Change log
 
 `co-log-core` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
-0.1.1
-=====
+## 0.1.1 — Nov 15, 2018
 
-* [#63](https://github.com/kowainik/co-log/issues/63)
-  Add `logPrint` and `logPrintStderr` to Colog.Core.IO
+* [#63](https://github.com/kowainik/co-log/issues/63):
+  Add `logPrint`, `logPrintStderr`, `logPrintHandle` and `withLogPrintFile` to `Colog.Core.IO`.
 * [#46](https://github.com/kowainik/co-log/issues/46):
   Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
-  `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
-* [#48](https://github.com/kowainik/co-log/issues/48)
+  `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`.
+* [#48](https://github.com/kowainik/co-log/issues/48):
   Adds `liftLogIO` function.
-* [#49](https://github.com/kowainik/co-log/issues/49)
-  Adds `<&` and `&>`operators for `unLogAction`.
+* [#49](https://github.com/kowainik/co-log/issues/49):
+  Add `<&` and `&>`operators for `unLogAction`.
+* [#47](https://github.com/kowainik/co-log/issues/47):
+  Add `doctest` tests.
+* [#13](https://github.com/kowainik/co-log/issues/13):
+  Add `.cabal` file description and improve documentation.
+* [#39](https://github.com/kowainik/co-log/issues/39):
+  Support GHC-8.2.2 and GHC-8.6.2.
 
-
-0.1.0
-=====
+## 0.1.0
 
 * [#38](https://github.com/kowainik/co-log/issues/38):
   Rename `cbind` to `cmapM`.
@@ -27,8 +29,8 @@ The change log is available [on GitHub][2].
 * [#37](https://github.com/kowainik/co-log/issues/37):
   Add `base` bounds.
 
-0.0.0
-=====
+## 0.0.0
+
 * Initially created.
 
 [1]: https://pvp.haskell.org

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -1,7 +1,20 @@
+cabal-version:       2.0
 name:                co-log-core
 version:             0.1.1
-description:         Logging library
-synopsis:            Logging library
+synopsis:            Composable Contravariant Comonadic Logging Library
+description:
+    This package provides core types and functions to work with the @LogAction@ data type which is both simple and powerful.
+    .
+    @
+    __newtype__ LogAction m msg = LogAction
+    \    { unLogAction :: msg -> m ()
+    \    }
+    @
+    .
+    The ideas behind this package are described in the following blog post:
+    .
+    * [co-log: Composable Contravariant Combinatorial Comonadic Configurable Convenient Logging](https://kowainik.github.io/posts/2018-09-25-co-log)
+
 homepage:            https://github.com/kowainik/co-log
 bug-reports:         https://github.com/kowainik/co-log/issues
 license:             MPL-2.0
@@ -12,10 +25,9 @@ copyright:           2018 Kowainik
 category:            Logging
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md
-cabal-version:       2.0
 tested-with:         GHC == 8.2.2
-                   , GHC == 8.4.3
-                   , GHC == 8.6.1
+                   , GHC == 8.4.4
+                   , GHC == 8.6.2
 
 source-repository head
   type:                git
@@ -44,6 +56,7 @@ library
   default-extensions:  ConstraintKinds
                        DeriveGeneric
                        GeneralizedNewtypeDeriving
+                       InstanceSigs
                        LambdaCase
                        OverloadedStrings
                        RecordWildCards
@@ -54,8 +67,9 @@ library
                        ViewPatterns
 
 test-suite doctest
-  build-depends:        base, doctest ^>= 0.16.0
+  type:                 exitcode-stdio-1.0
+  build-depends:        base >= 4.10 && < 4.13
+                      , doctest ^>= 0.16.0
   default-language:     Haskell2010
   hs-source-dirs:       test
   main-is:              Doctests.hs
-  type:                 exitcode-stdio-1.0

--- a/co-log-core/test/Doctests.hs
+++ b/co-log-core/test/Doctests.hs
@@ -7,6 +7,7 @@ import Test.DocTest (doctest)
 main :: IO ()
 main = doctest
     [ "-XInstanceSigs"
+    , "-XScopedTypeVariables"
     , "-XViewPatterns"
     , "src"
     ]

--- a/co-log/CHANGELOG.md
+++ b/co-log/CHANGELOG.md
@@ -1,28 +1,33 @@
-Change log
-==========
+# Change log
 
-`co-log uses` [PVP Versioning][1].
+`co-log` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
-0.2.0
-=====
+## 0.2.0 — Nov 15, 2018
 
+* [#45](https://github.com/kowainik/co-log/issues/45):
+  Introduce approach for concurrent log writing.
 * [#46](https://github.com/kowainik/co-log/issues/46):
   Moves `logStringStdout`, `logStringStderr`, `logStringHandle`,
   `withLogStringFile` from `Colog.Actions` to `Colog.Core.IO`
 * [#77](https://github.com/kowainik/co-log/issues/77):
   Remove `relude` from dependencies.
   Add HLint check to Travis CI.
+* [#64](https://github.com/kowainik/co-log/issues/64):
+  Introduce basic benchmarks.
+* [#20](https://github.com/kowainik/co-log/issues/20):
+  Add experimental support for logger rotation (see `Colog.Rotation` module).
+* [#39](https://github.com/kowainik/co-log/issues/39):
+  Support GHC-8.2.2 and GHC-8.6.2.
 
-0.1.0
-=====
+## 0.1.0
 
 * [#37](https://github.com/kowainik/co-log/issues/37):
   Add bounds to all dependencies. Move `Prelude` to the
   `other-modules` section.
 
-0.0.0
-=====
+## 0.0.0
+
 * Initially created.
 
 [1]: https://pvp.haskell.org

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -1,21 +1,28 @@
 cabal-version:       2.0
 name:                co-log
 version:             0.2.0
-description:         Logging library
-synopsis:            Logging library
+synopsis:            Composable Contravariant Comonadic Logging Library
+description:
+    The default implementation of logging based on
+    [co-log-core](http://hackage.haskell.org/package/co-log-core).
+    .
+    The ideas behind this package are described in the following blog post:
+    .
+    * [co-log: Composable Contravariant Combinatorial Comonadic Configurable Convenient Logging](https://kowainik.github.io/posts/2018-09-25-co-log)
+
 homepage:            https://github.com/kowainik/co-log
 bug-reports:         https://github.com/kowainik/co-log/issues
 license:             MPL-2.0
 license-file:        LICENSE
-author:              Kowainik
+author:              Kowainik, Alexander Vershilov
 maintainer:          xrom.xkov@gmail.com
 copyright:           2018 Kowainik
 category:            Logging
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md
 tested-with:         GHC == 8.2.2
-                   , GHC == 8.4.3
-                   , GHC == 8.6.1
+                   , GHC == 8.4.4
+                   , GHC == 8.6.2
 
 source-repository head
   type:                git
@@ -57,7 +64,7 @@ library
                        -fhide-source-paths
                        -freverse-errors
 
-  default-language:   Haskell2010
+  default-language:    Haskell2010
   default-extensions:  ConstraintKinds
                        DeriveGeneric
                        GeneralizedNewtypeDeriving

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.9
+resolver: lts-12.18
 
 packages:
   - co-log


### PR DESCRIPTION
Resolves #13 

I've updated `.cabal` description. Haven't checked it yet, just took `vec` package as an example:

* https://github.com/phadej/vec/blob/6eaa4f5ee258a709cab2342233f4539e73fd393a/vec/vec.cabal#L8-L60

Also I've update GHC versions in `.cabal` file and on Travis CI. And performed a couple more documentation improvements.