### PR TITLE
Add badges and fix docs

### DIFF
--- a/co-log-core/README.md
+++ b/co-log-core/README.md
@@ -1,8 +1,10 @@
 # co-log-core
 
-[![Hackage](https://img.shields.io/hackage/v/co-log.svg)](https://hackage.haskell.org/package/co-log-core)
-[![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/co-log/blob/master/LICENSE)
 [![Build status](https://secure.travis-ci.org/kowainik/co-log.svg)](https://travis-ci.org/kowainik/co-log)
+[![Hackage](https://img.shields.io/hackage/v/co-log.svg)](https://hackage.haskell.org/package/co-log-core)
+[![Stackage LTS](http://stackage.org/package/co-log-core/badge/lts)](http://stackage.org/lts/package/co-log-core)
+[![Stackage Nightly](http://stackage.org/package/co-log-core/badge/nightly)](http://stackage.org/nightly/package/co-log-core)
+[![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](https://github.com/kowainik/co-log/blob/master/LICENSE)
 
 
 Core data types and classes for composable logging library.

--- a/co-log-core/src/Colog/Core/Action.hs
+++ b/co-log-core/src/Colog/Core/Action.hs
@@ -136,7 +136,7 @@ action <& msg1 <& msg2
 doesn't make sense. Instead you want:
 
 @
-action <& msg1 >> action <& msg2
+action <& msg1 \>\> action <& msg2
 @
 
 In addition, because '<&' has higher precedence than the other operators in this

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -43,7 +43,7 @@ library
   build-depends:       base >= 4.10 && < 4.13
                      , ansi-terminal ^>= 0.8
                      , bytestring ^>= 0.10.8
-                     , co-log-core ^>= 0.1.0
+                     , co-log-core ^>= 0.1.1
                      , containers >= 0.5.7 && < 0.7
                      , contravariant ^>= 1.5
                      , directory ^>= 1.3.0


### PR DESCRIPTION
Adds stackage badges to `co-log-core` package due to this PR:

* https://github.com/commercialhaskell/stackage/pull/4135

Also couple extra fixes.