### PR TITLE
[#119] new action that logs a message without the severity information

### DIFF
--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -98,6 +98,7 @@ executable play-colog
   build-depends:       co-log
                      , mtl
                      , typerep-map
+                     , text
 
   ghc-options:         -threaded
                        -rtsopts

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -321,7 +321,7 @@ Practically, it formats a message as 'fmtRichMessageDefault' without the severit
 -}
 fmtSimpleRichMessageDefault :: MonadIO m => RichMsg m SimpleMsg -> m Text
 fmtSimpleRichMessageDefault msg = fmtRichMessageCustomDefault msg formatRichMessage
-   where
+  where
     formatRichMessage :: Maybe ThreadId -> Maybe C.Time -> SimpleMsg -> Text
     formatRichMessage (maybe "" showThreadId -> thread) (maybe "" showTime -> time) SimpleMsg{..} =
         time

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -271,7 +271,7 @@ defaultFieldMap = fromList
 
 -- | Contains additional data to 'Message' to display more verbose information.
 data RichMsg (m :: Type -> Type) (msg :: Type) = RichMessage
-    { richMsgMsg :: {-# UNPACK #-} !msg
+    { richMsgMsg :: !msg
     , richMsgMap :: {-# UNPACK #-} !(FieldMap m)
     } deriving (Functor)
 

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -321,7 +321,7 @@ Practically, it formats a message as 'fmtRichMessageDefault' without the severit
 -}
 fmtSimpleRichMessageDefault :: MonadIO m => RichMessage m -> m Text
 fmtSimpleRichMessageDefault msg = fmtRichMessageCustom msg formatRichMessage
-   where
+  where
     formatRichMessage :: Maybe ThreadId -> Maybe C.Time -> Message -> Text
     formatRichMessage (maybe "" showThreadId -> thread) (maybe "" showTime -> time) Msg{..} =
         time

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -43,7 +43,8 @@ module Colog.Message
        , FieldMap
        , defaultFieldMap
 
-       , RichMessage
+       , RichMessage(..)
+       , RichMsg(..)
        , SimpleMsg(..)
        , fmtRichMessageDefault
        , fmtSimpleRichMessageDefault
@@ -270,7 +271,7 @@ defaultFieldMap = fromList
     ]
 
 -- | Contains additional data to 'Message' to display more verbose information.
-data RichMsg (m :: Type -> Type) (msg :: Type) = RichMessage
+data RichMsg (m :: Type -> Type) (msg :: Type) = RichMessagex
     { richMsgMsg :: !msg
     , richMsgMap :: {-# UNPACK #-} !(FieldMap m)
     } deriving (Functor)
@@ -330,7 +331,7 @@ fmtSimpleRichMessageDefault msg = fmtRichMessageCustomDefault msg formatRichMess
      <> simpleMsgText
 
 fmtRichMessageCustomDefault :: MonadIO m => RichMsg m msg -> (Maybe ThreadId -> Maybe C.Time -> msg -> Text) -> m Text
-fmtRichMessageCustomDefault RichMessage{..} formatter = do
+fmtRichMessageCustomDefault RichMessagex{..} formatter = do
     maybeThreadId  <- extractField $ TM.lookup @"threadId"  richMsgMap
     maybePosixTime <- extractField $ TM.lookup @"posixTime" richMsgMap
     pure $ formatter maybeThreadId maybePosixTime richMsgMsg
@@ -358,4 +359,4 @@ upgradeMessageAction
 upgradeMessageAction fieldMap = cmap addMap
   where
     addMap :: Message -> RichMessage m
-    addMap msg = RichMessage msg fieldMap
+    addMap msg = RichMessagex msg fieldMap

--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -275,6 +275,7 @@ data RichMsg (m :: Type -> Type) (msg :: Type) = RichMessage
     , richMsgMap :: {-# UNPACK #-} !(FieldMap m)
     } deriving (Functor)
 
+-- | Specialised version of 'RichMsg' that stores severity, callstack and text message.
 type RichMessage m = RichMsg m Message
 
 {- | Formats 'RichMessage' in the following way:

--- a/co-log/tutorials/Main.hs
+++ b/co-log/tutorials/Main.hs
@@ -22,9 +22,9 @@ import Control.Monad.Reader (MonadReader, ReaderT (..))
 import Data.Semigroup ((<>))
 
 import Colog (pattern D, HasLog (..), LogAction, Message, Msg (..), PureLogger, WithLog, cmap,
-              cmapM, defaultFieldMap, fmtMessage, fmtRichMessageDefault, liftLogIO, log,
-              logException, logInfo, logMessagePure, logMsg, logMsgs, logPrint, logStringStdout,
-              logTextStderr, logTextStdout, logWarning, runPureLog, upgradeMessageAction,
+              cmapM, defaultFieldMap, fmtMessage, fmtSimpleRichMessageDefault, fmtRichMessageDefault,
+              liftLogIO, log, logException, logInfo, logMessagePure, logMsg, logMsgs, logPrint,
+              logStringStdout, logTextStderr, logTextStdout, logWarning, runPureLog, upgradeMessageAction,
               usingLoggerT, withLog, withLogTextFile, (*<), (<&), (>$), (>$<), (>*), (>*<), (>|<))
 
 import qualified Data.TypeRepMap as TM
@@ -168,15 +168,18 @@ main = withLogTextFile "co-log/example/example.log" $ \logTextFile -> do
 
     let simpleMessageAction = cmap  fmtMessage            textAction
     let richMessageAction   = cmapM fmtRichMessageDefault textAction
+    let simpleRichMessageAction = cmapM fmtSimpleRichMessageDefault textAction
 
     let fullMessageAction = upgradeMessageAction defaultFieldMap richMessageAction
     let semiMessageAction = upgradeMessageAction
                                 (TM.delete @"threadId" defaultFieldMap)
                                 richMessageAction
+    let severityLessMessageAction = upgradeMessageAction defaultFieldMap simpleRichMessageAction
 
     runApp simpleMessageAction
     runApp fullMessageAction
     runApp semiMessageAction
+    runApp severityLessMessageAction
 
     usingLoggerT carL $ logMsg $ Car "Toyota" "Corolla" (Pistons 4)
 


### PR DESCRIPTION
Resolves #119 

- I refactored a bit trying to avoid duplicate code as per hlint suggestions
- I ran play-colog and I can in fact see the logs without the severity information