### PR TITLE
Bump up polysemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ cabal.project.local
 .HTF/
 # Stack
 .stack-work/
+stack.yaml.lock
 
 ### IDE/support
 # Vim

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -79,7 +79,7 @@ library
                            Colog.Polysemy.Effect
 
   build-depends:       co-log-core ^>= 0.2.0.0
-                     , polysemy ^>= 0.5.1.0
+                     , polysemy ^>= 0.5.0.1
 
 executable play-colog-poly
   import:              common-options

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -34,8 +34,6 @@ source-repository head
   location:            https://github.com/kowainik/co-log.git
 
 common common-options
-  if impl(ghc < 8.6)
-      buildable:       False
   build-depends:       base >= 4.10.0.0 && < 4.13
 
   ghc-options:         -Wall
@@ -78,7 +76,7 @@ library
                            Colog.Polysemy.Effect
 
   build-depends:       co-log-core ^>= 0.2.0.0
-                     , polysemy ^>= 0.4.0.0
+                     , polysemy ^>= 0.5.1.0
 
 executable play-colog-poly
   import:              common-options

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -27,7 +27,9 @@ build-type:          Simple
 stability:           provisional
 extra-doc-files:     CHANGELOG.md
                    , README.md
-tested-with:         GHC == 8.6.5
+tested-with:         GHC == 8.2.2
+                   , GHC == 8.4.4
+                   , GHC == 8.6.5
 
 source-repository head
   type:                git
@@ -45,10 +47,11 @@ common common-options
                        -fhide-source-paths
                        -freverse-errors
                        -Wpartial-fields
-
-                       -- special options to make @polysemy@ fast
                        -O2
-                       -flate-specialise
+
+  -- special options to make @polysemy@ fast
+  if impl(ghc >= 8.6)
+    ghc-options:       -flate-specialise
                        -fspecialise-aggressively
 
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,7 @@
-resolver: nightly-2019-06-12
+resolver: nightly-2019-06-28
 
 packages:
   - co-log-core
   - co-log
   - co-log-polysemy
   - co-log-benchmark
-
-extra-deps:
-  - polysemy-0.4.0.0 


### PR DESCRIPTION
Now, `co-log-polysemy` should build with the latest 3 major versions of GHC.