### PR TITLE
Update polysemy ^>= 1.0

### DIFF
--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -27,7 +27,6 @@ build-type:          Simple
 stability:           provisional
 extra-doc-files:     CHANGELOG.md
                    , README.md
-tested-with:         GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.5
 
@@ -48,6 +47,10 @@ common common-options
                        -freverse-errors
                        -Wpartial-fields
                        -O2
+
+  -- 8.2 lacks <>
+  if impl(ghc < 8.4)
+    buildable: False
 
   -- special options to make @polysemy@ fast
   if impl(ghc >= 8.6)
@@ -79,7 +82,7 @@ library
                            Colog.Polysemy.Effect
 
   build-depends:       co-log-core ^>= 0.2.0.0
-                     , polysemy ^>= 0.5.0.1
+                     , polysemy ^>= 1.0
 
 executable play-colog-poly
   import:              common-options

--- a/co-log-polysemy/src/Colog/Polysemy/Effect.hs
+++ b/co-log-polysemy/src/Colog/Polysemy/Effect.hs
@@ -30,7 +30,7 @@ import Prelude hiding (log)
 
 import Colog.Core.Action (LogAction (..))
 import Data.Kind (Type)
-import Polysemy (Lift, Member, Sem, interpret, makeSem_, sendM)
+import Polysemy (Embed, Member, Sem, interpret, makeSem_, embed)
 import Polysemy.Output (Output (..), output)
 import Polysemy.Trace (Trace (..), trace)
 
@@ -81,12 +81,12 @@ Several examples:
 -}
 runLogAction
     :: forall m msg r a .
-       Member (Lift m) r
+       Member (Embed m) r
     => LogAction m msg
     -> Sem (Log msg ': r) a
     -> Sem r a
 runLogAction (LogAction action) = interpret $ \case
-    Log msg -> sendM $ action msg
+    Log msg -> embed $ action msg
 {-# INLINE runLogAction #-}
 
 {- | Run 'Log' as the 'Trace' effect. This function can be useful if you have an

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-06-28
+resolver: nightly-2019-07-26
 
 packages:
   - co-log-core


### PR DESCRIPTION
I am opening this PR before `0.8` is released, it is not meant to be merged yet.
If you want to use co-log with polysemy master see the [polysemy-0.8-submodules branch](https://github.com/Avi-D-coder/co-log/tree/polysemy-0.8-submodules).