### PR TITLE
Derive functor for Msg

### DIFF
--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -93,7 +93,7 @@ data Msg sev = Msg
     { msgSeverity :: !sev
     , msgStack    :: !CallStack
     , msgText     :: !Text
-    }
+    } deriving Functor
 
 data SimpleMsg = SimpleMsg
     { simpleMsgStack :: !CallStack


### PR DESCRIPTION
Usecase:

I am using Syslog Priorities (https://hackage.haskell.org/package/libsystemd-journal-1.4.1/docs/Systemd-Journal.html#t:Priority)
which are more fine-grained than Severities and I have a function ` Severity -> Priority` in my codebase such that I can
keep using existing code that already used `Severity`s and this allows me to integrate into `journald` without changing too much code