### PR TITLE
[#124] Implement concurrent playground for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ See the following tutorial series about the library:
 * [Intro: Using `LogAction`](https://github.com/kowainik/co-log/blob/master/co-log/tutorials/1-intro/Intro.md)
 * [Using custom monad that stores `LogAction` inside its environment](https://github.com/kowainik/co-log/blob/master/co-log/tutorials/2-custom/Custom.md)
 
+`co-log` also cares about concurrent logging. For this purposes we have the `concurrent-playground`
+executable where we experiment with different multithreading scenarios to test the library behavior.
+You can find it here:
+
+* [tutorials/Concurrent.hs](co-log/tutorials/Concurrent.hs)
+
 ## Benchmarks
 
 `co-log` is compared with basic functions like `putStrLn`. Since IO overhead is

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -105,6 +105,16 @@ executable play-colog
                        -rtsopts
                        -with-rtsopts=-N
 
+executable concurrent-playground
+  import:              common-options
+  hs-source-dirs:      tutorials
+  main-is:             Concurrent.hs
+  build-depends:       bytestring
+                     , co-log
+  ghc-options:         -threaded
+                       -rtsopts
+                       -with-rtsopts=-N
+
 executable readme
   import:              tutorial-options
   main-is:             README.lhs

--- a/co-log/tutorials/Concurrent.hs
+++ b/co-log/tutorials/Concurrent.hs
@@ -6,6 +6,7 @@ import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (forM_, replicateM_, void)
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 (pack)
+import Data.Semigroup ((<>))
 import Prelude hiding (log)
 
 import Colog (LogAction, logByteStringStderr, logByteStringStdout, (<&))

--- a/co-log/tutorials/Concurrent.hs
+++ b/co-log/tutorials/Concurrent.hs
@@ -1,0 +1,27 @@
+{- | The purpose of this module is to check concurrent abilities of @colog@.
+-}
+module Main (main) where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Monad (forM_, replicateM_, void)
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 (pack)
+import Prelude hiding (log)
+
+import Colog (LogAction, logByteStringStderr, logByteStringStdout, (<&))
+
+
+{- | Action that prints predefined message 5 times.
+-}
+action :: LogAction IO ByteString -> ByteString -> IO ()
+action log msg = replicateM_ 5 $ log <& msg
+
+{- | Checks @colog@ for interleaved output. Forks 10 threads, each of them runs
+'action'.
+-}
+main :: IO ()
+main = do
+    forM_ [1..10 :: Int] $ \i -> do
+        let log = if even i then logByteStringStdout else logByteStringStderr
+        void $ forkIO $ action log $ "Logging from thread: " <> pack (show i)
+    threadDelay $ 3 * (10 ^ (6 :: Int)) -- wait 3 seconds


### PR DESCRIPTION
Resolves #124

I tested it locally, I don't see any interleaved output. I see the following correct output:

```
Logging from thread: 4
Logging from thread: 5
Logging from thread: 3
Logging from thread: 6
Logging from thread: 1
Logging from thread: 2
Logging from thread: 10
Logging from thread: 8
Logging from thread: 4
Logging from thread: 6
Logging from thread: 7
Logging from thread: 2
Logging from thread: 10
Logging from thread: 8
Logging from thread: 4
Logging from thread: 9
Logging from thread: 6
Logging from thread: 2
Logging from thread: 10
```

So if somebody has problems with concurrent logging, we at least have a place to experiment with such problems...