### PR TITLE
Export showTime

### DIFF
--- a/co-log/src/Colog/Message.hs
+++ b/co-log/src/Colog/Message.hs
@@ -42,6 +42,7 @@ module Colog.Message
        , fmtMessage
        , showSeverity
        , showSourceLoc
+       , showTime
 
          -- * Externally extensible message type
          -- ** Field of the dependent map


### PR DESCRIPTION
This addresses #191.

Resolves #191

The `showTime` function is useful on it‘s own, especially for other logging solutions.