### PR TITLE
[#176] Add an action to flush a handle

### DIFF
--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -153,9 +153,11 @@ liftLogIO (LogAction action) = LogAction (liftIO . action)
 {-# INLINE liftLogIO #-}
 
 {- | This action can be used in combination with other actions to flush
-   a handle every time you log anything.
+a handle every time you log anything.
+
+@since x.x.x.x
 -}
 logFlush :: MonadIO m => Handle -> LogAction m a
 logFlush handle = LogAction $ const $ liftIO $ hFlush handle
 {-# INLINE logFlush #-}
-{-# SPECIALIZE logFlush :: Handle -> LogAction IO () #-}
+{-# SPECIALIZE logFlush :: Handle -> LogAction IO a #-}

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -32,6 +32,7 @@ module Colog.Core.IO
 
 import Colog.Core.Action (LogAction (..))
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Semigroup ((<>))
 import System.IO (Handle, IOMode (AppendMode), hFlush, hPrint, hPutStrLn, stderr, withFile)
 
 

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -44,6 +44,8 @@ import System.IO (Handle, IOMode (AppendMode), hFlush, hPrint, hPutStrLn, stderr
 ----------------------------------------------------------------------------
 
 {- | Action that prints 'String' to stdout.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logStringStdout <& "foo"
 foo
@@ -54,6 +56,8 @@ logStringStdout = LogAction (liftIO . putStrLn)
 {-# SPECIALIZE logStringStdout :: LogAction IO String #-}
 
 {- | Action that prints 'String' to stderr.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logStringStderr <& "foo"
 foo
@@ -64,6 +68,8 @@ logStringStderr = logStringHandle stderr
 {-# SPECIALIZE logStringStderr :: LogAction IO String #-}
 
 {- | Action that prints 'String' to 'Handle'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logStringHandle stderr <& "foo"
 foo
@@ -99,6 +105,8 @@ withLogStringFile path action = withFile path AppendMode $ \handle ->
 ----------------------------------------------------------------------------
 
 {- | Action that prints to stdout using 'Show'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logPrint <& 5
 5
@@ -109,6 +117,8 @@ logPrint = LogAction $ liftIO . print
 {-# SPECIALIZE logPrint :: Show a => LogAction IO a #-}
 
 {- | Action that prints to stderr using 'Show'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logPrintStderr <& 5
 5
@@ -119,6 +129,8 @@ logPrintStderr = logPrintHandle stderr
 {-# SPECIALIZE logPrintStderr :: Show a => LogAction IO a #-}
 
 {- | Action that prints to a 'Handle' using 'Show'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
 
 >>> logPrintHandle stderr <& 5
 5

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -27,11 +27,12 @@ module Colog.Core.IO
 
          -- * Various combinators
        , liftLogIO
+       , logFlush
        ) where
 
 import Colog.Core.Action (LogAction (..))
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import System.IO (Handle, IOMode (AppendMode), hPrint, hPutStrLn, stderr, withFile)
+import System.IO (Handle, IOMode (AppendMode), hFlush, hPrint, hPutStrLn, stderr, withFile)
 
 
 {- $setup
@@ -150,3 +151,11 @@ foo
 liftLogIO :: MonadIO m => LogAction IO msg -> LogAction m msg
 liftLogIO (LogAction action) = LogAction (liftIO . action)
 {-# INLINE liftLogIO #-}
+
+{- | This action can be used in combination with other actions to flush
+   a handle every time you log anything.
+-}
+logFlush :: MonadIO m => Handle -> LogAction m a
+logFlush handle = LogAction $ const $ liftIO $ hFlush handle
+{-# INLINE logFlush #-}
+{-# SPECIALIZE logFlush :: Handle -> LogAction IO () #-}

--- a/co-log-core/src/Colog/Core/IO.hs
+++ b/co-log-core/src/Colog/Core/IO.hs
@@ -78,7 +78,7 @@ implemented in continuation-passing style because it's more efficient to open
 file only once at the start of the application and write to 'Handle' instead of
 opening file each time we need to write to it.
 
-Opens file in 'AppendMode'.
+Opens file in 'AppendMode'. Automatically flushes the output buffer.
 
 #ifndef mingw32_HOST_OS
 
@@ -89,7 +89,8 @@ foo
 #endif
 -}
 withLogStringFile :: MonadIO m => FilePath -> (LogAction m String -> IO r) -> IO r
-withLogStringFile path action = withFile path AppendMode $ action . logStringHandle
+withLogStringFile path action = withFile path AppendMode $ \handle ->
+  action (logStringHandle handle <> logFlush handle)
 {-# INLINE withLogStringFile #-}
 {-# SPECIALIZE withLogStringFile :: FilePath -> (LogAction IO String -> IO r) -> IO r #-}
 
@@ -134,7 +135,8 @@ withLogPrintFile
     => FilePath
     -> (LogAction m a -> IO r)
     -> IO r
-withLogPrintFile path action = withFile path AppendMode $ action . logPrintHandle
+withLogPrintFile path action = withFile path AppendMode $ \handle ->
+  action (logPrintHandle handle <> logFlush handle)
 {-# INLINE withLogPrintFile #-}
 {-# SPECIALIZE withLogPrintFile :: Show a => FilePath -> (LogAction IO a -> IO r) -> IO r #-}
 

--- a/co-log/src/Colog/Actions.hs
+++ b/co-log/src/Colog/Actions.hs
@@ -26,6 +26,7 @@ module Colog.Actions
        ) where
 
 import Control.Monad.IO.Class (MonadIO (..))
+import Data.Semigroup ((<>))
 import Data.Text.Encoding (encodeUtf8)
 import System.IO (Handle, IOMode (AppendMode), stderr, withFile)
 

--- a/co-log/src/Colog/Actions.hs
+++ b/co-log/src/Colog/Actions.hs
@@ -30,6 +30,7 @@ import Data.Text.Encoding (encodeUtf8)
 import System.IO (Handle, IOMode (AppendMode), stderr, withFile)
 
 import Colog.Core.Action (LogAction (..), cmapM, (>$<))
+import Colog.Core.IO (logFlush)
 import Colog.Message (Message, defaultFieldMap, fmtMessage, fmtRichMessageDefault,
                       upgradeMessageAction)
 
@@ -64,7 +65,8 @@ logByteStringHandle handle = LogAction $ liftIO . BS8.hPutStrLn handle
 'Colog.Core.Action.withLogStringFile' for details.
 -}
 withLogByteStringFile :: MonadIO m => FilePath -> (LogAction m BS.ByteString -> IO r) -> IO r
-withLogByteStringFile path action = withFile path AppendMode $ action . logByteStringHandle
+withLogByteStringFile path action = withFile path AppendMode $ \handle ->
+  action (logByteStringHandle handle <> logFlush handle)
 {-# INLINE withLogByteStringFile #-}
 {-# SPECIALIZE withLogByteStringFile :: FilePath -> (LogAction IO BS.ByteString -> IO r) -> IO r #-}
 
@@ -94,7 +96,8 @@ logTextHandle handle = LogAction $ liftIO . TIO.hPutStrLn handle
 'Colog.Core.Action.withLogStringFile' for details.
 -}
 withLogTextFile :: MonadIO m => FilePath -> (LogAction m T.Text -> IO r) -> IO r
-withLogTextFile path action = withFile path AppendMode $ action . logTextHandle
+withLogTextFile path action = withFile path AppendMode $ \handle ->
+  action (logTextHandle handle <> logFlush handle)
 {-# INLINE withLogTextFile #-}
 {-# SPECIALIZE withLogTextFile :: FilePath -> (LogAction IO T.Text -> IO r) -> IO r #-}
 

--- a/co-log/src/Colog/Actions.hs
+++ b/co-log/src/Colog/Actions.hs
@@ -43,19 +43,28 @@ import qualified Data.Text.IO as TIO
 -- ByteString
 ----------------------------------------------------------------------------
 
-{- | Action that prints 'BS.ByteString' to stdout. -}
+{- | Action that prints 'BS.ByteString' to stdout.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logByteStringStdout :: MonadIO m => LogAction m BS.ByteString
 logByteStringStdout = LogAction $ liftIO . BS8.putStrLn
 {-# INLINE logByteStringStdout #-}
 {-# SPECIALIZE logByteStringStdout :: LogAction IO BS.ByteString #-}
 
-{- | Action that prints 'BS.ByteString' to stderr. -}
+{- | Action that prints 'BS.ByteString' to stderr.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logByteStringStderr :: MonadIO m => LogAction m BS.ByteString
 logByteStringStderr = logByteStringHandle stderr
 {-# INLINE logByteStringStderr #-}
 {-# SPECIALIZE logByteStringStderr :: LogAction IO BS.ByteString #-}
 
-{- | Action that prints 'BS.ByteString' to 'Handle'. -}
+{- | Action that prints 'BS.ByteString' to 'Handle'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logByteStringHandle :: MonadIO m => Handle -> LogAction m BS.ByteString
 logByteStringHandle handle = LogAction $ liftIO . BS8.hPutStrLn handle
 {-# INLINE logByteStringHandle #-}
@@ -74,19 +83,28 @@ withLogByteStringFile path action = withFile path AppendMode $ \handle ->
 -- Text
 ----------------------------------------------------------------------------
 
-{- | Action that prints 'T.Text' to stdout. -}
+{- | Action that prints 'T.Text' to stdout.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logTextStdout :: MonadIO m => LogAction m T.Text
 logTextStdout = LogAction $ liftIO . TIO.putStrLn
 {-# INLINE logTextStdout #-}
 {-# SPECIALIZE logTextStdout :: LogAction IO T.Text #-}
 
-{- | Action that prints 'T.Text' to stderr. -}
+{- | Action that prints 'T.Text' to stderr.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logTextStderr :: MonadIO m => LogAction m T.Text
 logTextStderr = logTextHandle stderr
 {-# INLINE logTextStderr #-}
 {-# SPECIALIZE logTextStderr :: LogAction IO T.Text #-}
 
-{- | Action that prints 'T.Text' to 'Handle'. -}
+{- | Action that prints 'T.Text' to 'Handle'.
+This action does not flush the output buffer.
+If buffering mode is block buffering, the effect of this action can be delayed.
+-}
 logTextHandle :: MonadIO m => Handle -> LogAction m T.Text
 logTextHandle handle = LogAction $ liftIO . TIO.hPutStrLn handle
 {-# INLINE logTextHandle #-}


### PR DESCRIPTION
I find it quite disappointing that actions provided out of the box do not flush output buffers. I have found a couple of relevant issues: #176 and #184. AFAIU it was supposed to be resolved already, but apparently it's not, so I went ahead and opened this PR.

For now I only add `logFlush` action which I believe is useful on its own as a basic building block for other actions. For example, if you want to log to `stderr`, you can construct the following action: `logPrintStderr <> logFlush stderr`. This PR is WIP because we should decide what to do further.

I propose to update all actions that write to a handle (be it a file or a standard handle) to flush by default. That's in line with this comment: https://github.com/kowainik/co-log/issues/176#issuecomment-578730791

Then the only question I have is whether to still provide functions that write to handles and do NOT flush. Maybe there are some specific cases when it's desirable, but I believe that's quite unlikely. So I see two options:
1. For each action like `logStringStdout` we also define `logStringStdoutNoFlush` (maybe with a different name). The advantage is that we support such (presumably rare) specific cases. The disadvantage is that there will be 2x more actions while there are quite a lot of them already.
2. Only update existing actions so that all of them do `hFlush`. The advatanges and disadvantages are reverse to the previous one.

I vote for the second option. Once I get an approval for either of this options, I can finish this PR.

P. S. Even though for `stdout` and `stderr` buffering mode is usually line buffering, it's not guaranteed and not always the case (e. g. if you run something from a `Makefile`). That's why I think that `stdout` and `stderr` logging should flush the respective handle as well.

## Issue

Resolves #176