### PR TITLE
Export HasLog from Colog.Monad

### DIFF
--- a/co-log/src/Colog/Monad.hs
+++ b/co-log/src/Colog/Monad.hs
@@ -10,6 +10,7 @@ Core of the @mtl@ implementation.
 
 module Colog.Monad
        ( LoggerT (..)
+       , HasLog (..)
        , WithLog
        , logMsg
        , logMsgs


### PR DESCRIPTION
I browsed the co-log documentation at http://hackage.haskell.org/package/co-log-0.4.0.1/docs/Colog-Monad.html and wondered where HasLog is coming from or what it was. This PR exposes HasLog from Colog.Monad hopefully simplifying import lists and reducing confusion.

(Also, great talk on Stan over at haskell.love)