### PR TITLE
GHC 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        cabal: ["3.0"]
+        cabal: ["3.4"]
         ghc:
           - "8.2.2"
           - "8.4.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - "8.6.5"
           - "8.8.3"
           - "8.10.1"
+          - "9.0.1"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,12 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1.2
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
+        enable-stack: false
 
     - uses: actions/cache@v1
       name: Cache ~/.cabal/store

--- a/co-log-benchmark/co-log-benchmark.cabal
+++ b/co-log-benchmark/co-log-benchmark.cabal
@@ -19,6 +19,7 @@ tested-with:         GHC == 8.2.2
                      GHC == 8.6.5
                      GHC == 8.8.3
                      GHC == 8.10.1
+                     GHC == 9.0.1
 
 source-repository head
   type:              git
@@ -28,7 +29,7 @@ executable co-log-bench
   main-is:             Main.hs
   if os(windows)
     buildable: False
-  build-depends:       base >= 4.10.1.0 && < 4.15
+  build-depends:       base >= 4.10.1.0 && < 4.16
                      , bytestring
                      , co-log
                      , text

--- a/co-log-core/CHANGELOG.md
+++ b/co-log-core/CHANGELOG.md
@@ -3,6 +3,11 @@
 `co-log-core` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+## 0.2.1.2 — <M> <d>, 2021
+
+* [#223](https://github.com/kowainik/co-log/pulls/223):
+  Support GHC-9.0.1.
+
 ## 0.2.1.1 — Apr 18, 2020
 
 * [#186](https://github.com/kowainik/co-log/issues/186):

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                co-log-core
-version:             0.2.1.1
+version:             0.2.1.2
 synopsis:            Composable Contravariant Comonadic Logging Library
 description:
     This package provides core types and functions to work with the @LogAction@ data type which is both simple and powerful.

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -38,13 +38,14 @@ tested-with:         GHC == 8.2.2
                      GHC == 8.6.5
                      GHC == 8.8.3
                      GHC == 8.10.1
+                     GHC == 9.0.1
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/co-log.git
 
 common common-options
-  build-depends:       base >= 4.10.1.0 && < 4.15
+  build-depends:       base >= 4.10.1.0 && < 4.16
 
   ghc-options:         -Wall
                        -Wcompat

--- a/co-log-core/co-log-core.cabal
+++ b/co-log-core/co-log-core.cabal
@@ -92,5 +92,5 @@ test-suite doctest
   type:                 exitcode-stdio-1.0
   hs-source-dirs:       test
   main-is:              Doctests.hs
-  build-depends:        doctest >= 0.16.0 && < 0.18
+  build-depends:        doctest >= 0.16.0 && < 0.19
                       , Glob ^>= 0.10.0

--- a/co-log-polysemy/CHANGELOG.md
+++ b/co-log-polysemy/CHANGELOG.md
@@ -3,6 +3,12 @@
 `co-log-polysemy` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.0.1.3 — <M> <d>, 2021
+
+* [#223](https://github.com/kowainik/co-log/pulls/223):
+  Support GHC-9.0.1.
+  Allow `polysemy-1.6.0.0`.
+
 ## 0.0.1.2 — Apr 18, 2020
 
 * [#186](https://github.com/kowainik/co-log/issues/186):

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                co-log-polysemy
-version:             0.0.1.2
+version:             0.0.1.3
 synopsis:            Composable Contravariant Comonadic Logging Library
 description:
     Implementation of the [co-log](http://hackage.haskell.org/package/co-log-core)

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -31,13 +31,14 @@ tested-with:         GHC == 8.4.4
                      GHC == 8.6.5
                      GHC == 8.8.3
                      GHC == 8.10.1
+                     GHC == 9.0.1
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/co-log.git
 
 common common-options
-  build-depends:       base >= 4.10.1.0 && < 4.15
+  build-depends:       base >= 4.10.1.0 && < 4.16
 
   -- 8.2 lacks <>
   if impl(ghc < 8.4)

--- a/co-log-polysemy/co-log-polysemy.cabal
+++ b/co-log-polysemy/co-log-polysemy.cabal
@@ -91,7 +91,7 @@ library
                            Colog.Polysemy.Effect
 
   build-depends:       co-log-core ^>= 0.2.0.0
-                     , polysemy >= 1.2.0.0 && < 1.6
+                     , polysemy >= 1.2.0.0 && < 1.7
 
 executable play-colog-poly
   import:              common-options

--- a/co-log/CHANGELOG.md
+++ b/co-log/CHANGELOG.md
@@ -3,6 +3,12 @@
 `co-log` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.4.0.2 — <M> <d>, 2021
+
+* [#223](https://github.com/kowainik/co-log/pulls/223):
+  Support GHC-9.0.1.
+  Require typerep-map ^>= 0.4
+
 ## 0.4.0.1 — Apr 18, 2020
 
 * [#186](https://github.com/kowainik/co-log/issues/186):

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -26,13 +26,14 @@ tested-with:         GHC == 8.2.2
                      GHC == 8.6.5
                      GHC == 8.8.3
                      GHC == 8.10.1
+                     GHC == 9.0.1
 
 source-repository head
   type:                git
   location:            https://github.com/kowainik/co-log.git
 
 common common-options
-  build-depends:       base >= 4.10.1.0 && < 4.15
+  build-depends:       base >= 4.10.1.0 && < 4.16
 
   ghc-options:         -Wall
                        -Wcompat

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -100,7 +100,7 @@ library
                      , text ^>= 1.2.3
                      , chronos ^>= 1.1
                      , transformers ^>= 0.5
-                     , typerep-map ^>= 0.3.2
+                     , typerep-map ^>= 0.4
                      , vector ^>= 0.12.0.3
 
 executable play-colog

--- a/co-log/co-log.cabal
+++ b/co-log/co-log.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                co-log
-version:             0.4.0.1
+version:             0.4.0.2
 synopsis:            Composable Contravariant Comonadic Logging Library
 description:
     The default implementation of logging based on [co-log-core](http://hackage.haskell.org/package/co-log-core).


### PR DESCRIPTION
Relaxes `base` bounds, bumps `typerep-map` and `polysemy`.