### PR TITLE
Indicate that `markdown-unlit` is needed to build examples.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,5 +21,5 @@ jobs:
       - uses: haskell-actions/hackage-publish@v1.1
         with:
           hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-          publish: false
+          publish: true
         if: steps.autotag.outputs.created

--- a/co-log.cabal
+++ b/co-log.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                co-log
-version:             0.6.0.0
+version:             0.6.0.1
 synopsis:            Composable Contravariant Comonadic Logging Library
 description:
     The default implementation of logging based on [co-log-core](http://hackage.haskell.org/package/co-log-core).
@@ -74,6 +74,7 @@ common tutorial-options
   if os(windows)
     buildable:         False
   build-depends:       co-log-core
+                       , markdown-unlit >= 0.6.0 && < 0.7
                        , text
 
   build-tool-depends:  markdown-unlit:markdown-unlit


### PR DESCRIPTION
Avoid error messages like: 
```
Building executable 'tutorial-intro' for co-log-0.6.0.0..
ghc: could not execute: markdown-unlit
```